### PR TITLE
Add JSON Schemas

### DIFF
--- a/Capacity.json
+++ b/Capacity.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Capacity.json",
 	"data": [
 		{
 			"idString": "passengers",

--- a/Capacity.json
+++ b/Capacity.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Capacity.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Capacity.json",
 	"data": [
 		{
 			"idString": "passengers",

--- a/DelayModel.json
+++ b/DelayModel.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/DelayModel.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/DelayModel.json",
 	"data": [
 		{
 			"type": 0,

--- a/DelayModel.json
+++ b/DelayModel.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/DelayModel.json",
 	"data": [
 		{
 			"type": 0,

--- a/Path.json
+++ b/Path.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Path.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Path.json",
 	"data": [
 		{
 			"name": "Linke Rheinstrecke",

--- a/Path.json
+++ b/Path.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Path.json",
 	"data": [
 		{
 			"name": "Linke Rheinstrecke",

--- a/Station.json
+++ b/Station.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Station.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Station.json",
 	"data": [
 		{
 			"group": 0,

--- a/Station.json
+++ b/Station.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Station.json",
 	"data": [
 		{
 			"group": 0,

--- a/Station.json
+++ b/Station.json
@@ -1460,15 +1460,6 @@
 		},
 		{
 			"group": 2,
-			"name": "Frankfurt-Höchst",
-			"ril100": "FHOE",
-			"x": 275,
-			"y": 280,
-			"platformLength": 230,
-			"platforms": 12
-		},
-		{
-			"group": 2,
 			"name": "Neckargemünd",
 			"ril100": "RNM",
 			"x": 305,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/TaskModel.json",
 	"data": [
 		{
 			"group": 1,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/TaskModel.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/TaskModel.json",
 	"data": [
 		{
 			"group": 1,

--- a/Train.json
+++ b/Train.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Train.json",
+	"$schema": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Train.json",
 	"data": [
 		{
 			"id": 13,

--- a/Train.json
+++ b/Train.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Train.json",
 	"data": [
 		{
 			"id": 13,

--- a/Train.json
+++ b/Train.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
 	"data": [
 		{
 			"id": 13,

--- a/Train.json
+++ b/Train.json
@@ -81,7 +81,6 @@
 				{"name": "passengers", "value": 918}
 			]
 		},
-
 		{
 
 			"id": 605,

--- a/schemas/Capacity.json
+++ b/schemas/Capacity.json
@@ -34,6 +34,13 @@
 					"emoji": {
 						"description": "Emoji der Einheit",
 						"type": "string"
+					},
+					"objects": {
+						"description": "Sub-Ladungsarten, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				}
 			},

--- a/schemas/Capacity.json
+++ b/schemas/Capacity.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Capacity.json",
+	"title": "Art der Beladungen eines Fahrzeugs",
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"idString": {
+						"description": "Eindeutige ID einer Capacity",
+						"type": "integer",
+						"minimum": 0
+					},
+					"name": {
+						"description": "Name der Capacity",
+						"type": "string"
+					},
+					"needsPlatform": {
+						"description": "Benötigt einen bahnsteig?",
+						"type": "boolean"
+					},
+					"unit": {
+						"description": "Einheit der Capacity",
+						"type": "string"
+					},
+					"unitMass": {
+						"description": "Masse einer Einheit in t",
+						"type": "number",
+						"minimum": 0
+					},
+					"emoji": {
+						"description": "Emoji der Einheit",
+						"type": "string"
+					}
+				}
+			},
+			"required": [
+				"idString",
+				"name",
+				"needsPlatform",
+				"unit",
+				"unitMass",
+				"emoji"
+			],
+			"uniqueItems": true
+		}
+	}
+}

--- a/schemas/Capacity.json
+++ b/schemas/Capacity.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Capacity.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Capacity.json",
 	"title": "Art der Beladungen eines Fahrzeugs",
 	"type": "object",
 	"properties": {

--- a/schemas/Capacity.json
+++ b/schemas/Capacity.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Capacity.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Capacity.json",
 	"title": "Art der Beladungen eines Fahrzeugs",
 	"type": "object",
 	"properties": {

--- a/schemas/Capacity.json
+++ b/schemas/Capacity.json
@@ -11,7 +11,7 @@
 				"properties": {
 					"idString": {
 						"description": "Eindeutige ID einer Capacity",
-						"type": "integer",
+						"type": "string",
 						"minimum": 0
 					},
 					"name": {

--- a/schemas/DelayModel.json
+++ b/schemas/DelayModel.json
@@ -1,0 +1,56 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/DelayModel.json",
+	"title": "Modelle für Verspätungen",
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"type": {
+						"description": "Art der Verspätung",
+						"type": "integer",
+						"oneOf": [
+							{"const": 0, "description": "Fahrzeugstörung"},
+							{"const": 1, "description": "Personal"},
+							{"const": 2, "description": "Ladung"},
+							{"const": 3, "description": "Streckenstörung (noch nicht implementiert)"},
+							{"const": 4, "description": "Fahrplan"}
+						]
+					},
+					"name": {
+						"description": "Verspätungstext",
+						"type": "string"
+					},
+					"delay": {
+						"description": "Erzeugte Verspätung in Sekunden (+/-5%)",
+						"type": "integer"
+					}
+				},
+				"if": {
+					"properties": {
+						"type": {
+							"const": 2
+						}
+					}
+				},
+				"then": {
+					"properties": {
+						"capacity": {
+							"description": "Die Ladungsart, für die die Störung gilt",
+							"type": "string"
+						}
+					}
+				},
+				"required": [
+					"type",
+					"name",
+					"delay"
+				],
+				"uniqueItems": true
+			}
+		}
+	}
+}

--- a/schemas/DelayModel.json
+++ b/schemas/DelayModel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/DelayModel.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/DelayModel.json",
 	"title": "Modelle für Verspätungen",
 	"type": "object",
 	"properties": {

--- a/schemas/DelayModel.json
+++ b/schemas/DelayModel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/DelayModel.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/DelayModel.json",
 	"title": "Modelle für Verspätungen",
 	"type": "object",
 	"properties": {

--- a/schemas/DelayModel.json
+++ b/schemas/DelayModel.json
@@ -27,6 +27,13 @@
 					"delay": {
 						"description": "Erzeugte Verspätung in Sekunden (+/-5%)",
 						"type": "integer"
+					},
+					"objects": {
+						"description": "Sub-Verspätungen, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				},
 				"if": {

--- a/schemas/Path.json
+++ b/schemas/Path.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Path.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Path.json",
 	"title": "Verbindungen zwischen zwei Bahnhöfen",
 	"type": "object",
 	"properties": {

--- a/schemas/Path.json
+++ b/schemas/Path.json
@@ -1,0 +1,83 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Path.json",
+	"title": "Verbindungen zwischen zwei Bahnhöfen",
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Streckenname",
+						"type": "string"
+					},
+					"group": {
+						"description": "Art der Strecke",
+						"type": "integer",
+						"oneOf": [
+							{"const": 0, "description": "Hauptbahn"},
+							{"const": 1, "description": "Nebenbahn"},
+							{"const": 2, "description": "SFS"}
+						],
+						"default": 0
+					},
+					"start": {
+						"description": "Ril100 des Startbahnhofs",
+						"type": "string",
+						"minLength": 2,
+						"maxLength": 5
+					},
+					"end": {
+						"description": "Ril100 des Endbahnhofs",
+						"type": "string",
+						"minLength": 2,
+						"maxLength": 5
+					},
+					"twistingFactor": {
+						"description": "Kurvigkeit. 1 ist am kurvigsten",
+						"type": "number",
+						"minimum": 0,
+						"maximum": 1
+					},
+					"length": {
+						"description": "Länge der Strecke",
+						"type": "integer",
+						"minimum": 0
+					},
+					"maxSpeed": {
+						"description": "Höchstgeschwindigkeit des Streckenabschnitts",
+						"type": "integer",
+						"minimum": 1
+					},
+					"electrified": {
+						"description": "Elektrifiziert",
+						"type": "boolean",
+						"default": true
+					},
+					"neededEquipments": {
+						"description": "Benötigte Fahrzeugausstattung",
+						"type": "array",
+						"items": {
+							"type": "string",
+							"examples": [
+								"ETCS",
+								"KRM",
+								"FR"
+							]
+						}
+					}
+				},
+				"required": [
+					"start",
+					"end",
+					"twistingFactor",
+					"length",
+					"maxSpeed"
+				],
+				"uniqueItems": true
+			}
+		}
+	}
+}

--- a/schemas/Path.json
+++ b/schemas/Path.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Path.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Path.json",
 	"title": "Verbindungen zwischen zwei Bahnhöfen",
 	"type": "object",
 	"properties": {

--- a/schemas/Path.json
+++ b/schemas/Path.json
@@ -67,6 +67,13 @@
 								"FR"
 							]
 						}
+					},
+					"objects": {
+						"description": "Sub-Routen, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				},
 				"required": [

--- a/schemas/Station.json
+++ b/schemas/Station.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Station.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Station.json",
 	"title": "Bahnhöfe",
 	"type": "object",
 	"properties": {

--- a/schemas/Station.json
+++ b/schemas/Station.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Station.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Station.json",
 	"title": "Bahnhöfe",
 	"type": "object",
 	"properties": {

--- a/schemas/Station.json
+++ b/schemas/Station.json
@@ -51,6 +51,13 @@
 					"forRandomTasks": {
 						"type": "boolean",
 						"default": true
+					},
+					"objects": {
+						"description": "Sub-Stationen, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				},
 				"required": [

--- a/schemas/Station.json
+++ b/schemas/Station.json
@@ -1,0 +1,67 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Station.json",
+	"title": "Bahnhöfe",
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Bahnhofsname",
+						"type": "string"
+					},
+					"ril100": {
+						"description": "Ril100 des Bf",
+						"type": "string",
+						"minLength": 2,
+						"maxLength": 5
+					},
+					"group": {
+						"description": "Art des Bahnhofs",
+						"type": "integer",
+						"oneOf": [
+							{"const": 0, "description": "Knotenbahnhof"},
+							{"const": 1, "description": "Hauptbahnhof"},
+							{"const": 2, "description": "kleiner Bahnhof"}
+						]
+					},
+					"x": {
+						"description": "x-Position auf Karte",
+						"type": "integer"
+					},
+					"y": {
+						"description": "y-Position auf Karte",
+						"type": "integer"
+					},
+					"platformLength": {
+						"description": "maximale Bahnsteiglänge",
+						"type": "integer",
+						"minimum": 0,
+						"default": 0
+					},
+					"platforms": {
+						"description": "Bahnsteiganzahl",
+						"type": "integer",
+						"minimum": 0,
+						"default": 0
+					},
+					"forRandomTasks": {
+						"type": "boolean",
+						"default": true
+					}
+				},
+				"required": [
+					"name",
+					"ril100",
+					"group",
+					"x",
+					"y"
+				]
+			},
+			"uniqueItems": true
+		}
+	}
+}

--- a/schemas/TaskModel.json
+++ b/schemas/TaskModel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/TaskModel.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/TaskModel.json",
 	"title": "Modelle für Aufträge, aus denen automatisch neue Aufträge erstellt werden",
 	"type": "object",
 	"properties": {

--- a/schemas/TaskModel.json
+++ b/schemas/TaskModel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/TaskModel.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/TaskModel.json",
 	"title": "Modelle für Aufträge, aus denen automatisch neue Aufträge erstellt werden",
 	"type": "object",
 	"properties": {

--- a/schemas/TaskModel.json
+++ b/schemas/TaskModel.json
@@ -98,6 +98,13 @@
 								}
 							}
 						}
+					},
+					"objects": {
+						"description": "Sub-Aufgaben, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				},
 				"required": [

--- a/schemas/TaskModel.json
+++ b/schemas/TaskModel.json
@@ -1,0 +1,114 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/TaskModel.json",
+	"title": "Modelle für Aufträge, aus denen automatisch neue Aufträge erstellt werden",
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"group": {
+						"description": "Art des Auftrags",
+						"type": "integer",
+						"oneOf": [
+							{"const": 0, "description": "Direktvergabe"},
+							{"const": 1, "description": "Ausschreibung"}
+						]
+					},
+					"name": {
+						"description": "Name des Auftrags\n%s als Platzhalter für Start/Ziel",
+						"type": "string"
+					},
+					"descriptions": {
+						"description": "Beschreibung(en) der Ausschreibung",
+						"type": "array",
+						"items": {
+							"type": "string",
+							"description": "%s als Platzhalter für Start/Ziel"
+						}
+					},
+					"plops": {
+						"description": "Verdienst für die Ausschreibung",
+						"type": "integer",
+						"minimum": 0
+					},
+					"plopDifference": {
+						"description": "Zufällige Abweichung des Verdiensts in Prozent +/-",
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 100,
+						"default": 5
+					},
+					"stations": {
+						"description": "Ril100 aller Bahnhöfe, die angefahren werden sollen in der richtigen Reihenfolge.\nWird keiner angegeben, werden zwei zufällige gewählt.",
+						"type": "array",
+						"items": {
+							"type": "string",
+							"minLength": 2,
+							"maxLength": 5
+						}
+					},
+					"neededCapacity": {
+						"description": "Art der Beladung und Menge.",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"description": "Art der Ladung",
+									"type": "string",
+									"examples": [
+										"passengers",
+										"wood",
+										"oil",
+										"cars",
+										"containers",
+										"castor"
+									]
+								}
+							},
+							"if": {
+								"properties": {
+									"name": {
+										"const": "passengers"
+									}
+								}
+							},
+							"then": {
+								"properties": {
+									"value": {
+										"description": "Anzahl der Fahrgäste",
+										"type": "integer",
+										"oneOf": [
+											{"const": 0, "description": "Automatisch"},
+											{"minimum": 1}
+										]
+									}
+								}
+							},
+							"else": {
+								"properties": {
+									"value": {
+										"description": "Menge der Ladung",
+										"type": "integer",
+										"minimum": 1
+									}
+								}
+							}
+						}
+					}
+				},
+				"required": [
+					"group",
+					"name",
+					"descriptions",
+					"plops",
+					"neededCapacity"
+				],
+				"uniqueItems": true
+			}
+		}
+	}
+}

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -1,0 +1,202 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
+	"title": "Liste der Zug-Baureihen",
+	"type": "object",
+	"properties": {
+		"data" : {
+			"description": "Die Züge, die in TrainCompany zur Verfügung stehen",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"description": "Eindeutige ID des Fz",
+						"type": "integer",
+						"minimum": 1
+					},
+					"group": {
+						"description": "Art des Fahrzeugs",
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 3,
+						"examples": [
+							"0 - Lokomotive",
+							"1 - Wagen",
+							"2 - Triebzug",
+							"3 - fixer Wagenverband"
+						]
+					},
+					"name": {
+						"description": "Name des Fahrzeugs",
+						"type": "string"
+					},
+					"shortcut": {
+						"description": "Baureihen/-art-Bezeichnung des Fahrzeugs",
+						"type": "string"
+					},
+					"speed": {
+						"description": "Höchstgeschwindigkeit in km/h",
+						"type": "integer",
+						"minimum": 0
+					},
+					"weight": {
+						"description": "Gewicht in t",
+						"type": "integer",
+						"minimum": 0
+					},
+					"force": {
+						"description": "Anfahrzugkraft in kN",
+						"type": "integer",
+						"minimum": 0
+					},
+					"length": {
+						"description": "Länge in m",
+						"type": "integer",
+						"minimum": 0
+					},
+					"drive": {
+						"description": "Traktionsart",
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 2,
+						"examples": [
+							"0 - Keine Traktion",
+							"1 - E-Traktion",
+							"2 - Diesel-Traktion"
+						]
+					},
+					"reliability": {
+						"description": "Zuverlässigkeit in Prozent",
+						"type": "number",
+						"minimum": 0,
+						"maximum": 1
+					},
+					"cost": {
+						"description": "Kosten in Plops",
+						"type": "integer",
+						"minimum": 0
+					},
+					"operationCosts": {
+						"description": "Betriebskosten pro km in Plops",
+						"type": "integer",
+						"minimum": 0
+					},
+					"equipments": {
+						"description": "Fahrzeugausstattung",
+						"type": "array",
+						"items": {
+							"type": "string",
+							"examples": [
+								"ETCS",
+								"KRM",
+								"FR"
+							]
+						},
+						"uniqueItems": true
+					},
+					"exchangeTime": {
+						"description": "Aufenthaltsdauer bei Planhalten in Sekunden",
+						"type": "integer",
+						"minimum": 0,
+						"default": 40
+					},
+					"capacity": {
+						"description": "Art der Beladung und Menge",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"description": "Art der Beladung",
+									"type": "string",
+									"examples": [
+										"passengers",
+										"wood",
+										"oil",
+										"cars",
+										"containers",
+										"castor"
+									]
+								},
+								"value": {
+									"description": "Menge der Beladung",
+									"type": "integer",
+									"minimum": 1
+								}
+							},
+							"required": [
+								"name",
+								"value"
+							],
+							"uniqueItems": true
+						}
+					}
+				},
+				"allOf": [
+					{
+						"if": {
+							"properties": { 
+								"group": { 
+									"minimum": 2,
+									"maximum": 3
+								}
+							}
+						},
+						"then": {
+							"properties": {
+								"maxConnectedUnits": {
+									"description": "Maximale Anzahl der kuppelbaren Einheiten",
+									"type": "integer",
+									"minimum": 0,
+									"examples": [
+										"0 - unbegrenzt"
+									]
+								},
+								"compatibleWith": {
+									"description": "Lässt sich zusätzlich mit den angegebenen Fz kuppeln",
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					},
+					{
+						"if": {
+							"properties": {
+								"group": {
+									"const": 3
+								}
+							}
+						},
+						"then": {
+							"properties": {
+								"equivalentTo": {
+									"description": "Entspricht wie vielen Wagen?",
+									"type": "integer",
+									"minimum": 1
+								}
+							}
+						}
+					}
+				],
+				"required": [
+					"id",
+					"group",
+					"name",
+					"speed",
+					"weight",
+					"force",
+					"length",
+					"drive",
+					"reliability",
+					"cost",
+					"operationCosts"
+				]
+			},
+			"uniqueItems": true
+		}
+	}
+}

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Train.json",
+	"$id": "https://raw.githubusercontent.com/marhei/TrainCompany-Data/main/schemas/Train.json",
 	"title": "Liste der Zug-Baureihen",
 	"type": "object",
 	"properties": {

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft-07/schema",
-	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
+	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/schema/schemas/Train.json",
 	"title": "Liste der Zug-Baureihen",
 	"type": "object",
 	"properties": {

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
 	"title": "Liste der Zug-Baureihen",
 	"type": "object",

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"$id": "https://raw.githubusercontent.com/C1710/TrainCompany-Data/main/Train.json",
 	"title": "Liste der Zug-Baureihen",
 	"type": "object",

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -13,7 +13,7 @@
 					"id": {
 						"description": "Eindeutige ID des Fz",
 						"type": "integer",
-						"minimum": 1
+						"minimum": 0
 					},
 					"group": {
 						"description": "Art des Fahrzeugs",
@@ -157,7 +157,8 @@
 									"description": "Lässt sich zusätzlich mit den angegebenen Fz kuppeln",
 									"type": "array",
 									"items": {
-										"type": "string"
+										"type": "integer",
+										"minimum": 0
 									}
 								}
 							}
@@ -192,8 +193,7 @@
 					"length",
 					"drive",
 					"reliability",
-					"cost",
-					"operationCosts"
+					"cost"
 				]
 			},
 			"uniqueItems": true

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -18,13 +18,11 @@
 					"group": {
 						"description": "Art des Fahrzeugs",
 						"type": "integer",
-						"minimum": 0,
-						"maximum": 3,
-						"examples": [
-							"0 - Lokomotive",
-							"1 - Wagen",
-							"2 - Triebzug",
-							"3 - fixer Wagenverband"
+						"oneOf": [
+							{"const": 0, "description": "Lokomotive"},
+							{"const": 1, "description": "Wagen"},
+							{"const": 2, "description": "Triebzug"},
+							{"const": 3, "description": "fixer Wagenverband"}
 						]
 					},
 					"name": {
@@ -58,12 +56,10 @@
 					"drive": {
 						"description": "Traktionsart",
 						"type": "integer",
-						"minimum": 0,
-						"maximum": 2,
-						"examples": [
-							"0 - Keine Traktion",
-							"1 - E-Traktion",
-							"2 - Diesel-Traktion"
+						"oneOf": [
+							{"const": 0, "description": "Keine Traktion"},
+							{"const": 1, "description": "E-Traktion"},
+							{"const": 2, "description": "Diesel-Traktion"}
 						]
 					},
 					"reliability": {
@@ -148,10 +144,11 @@
 								"maxConnectedUnits": {
 									"description": "Maximale Anzahl der kuppelbaren Einheiten",
 									"type": "integer",
-									"minimum": 0,
-									"examples": [
-										"0 - unbegrenzt"
-									]
+									"oneOf": [
+										{"const": 0, "description": "unbegrenzt"},
+										{"minimum": 1}
+									],
+									"default": 0
 								},
 								"compatibleWith": {
 									"description": "Lässt sich zusätzlich mit den angegebenen Fz kuppeln",

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -136,8 +136,8 @@
 				"allOf": [
 					{
 						"if": {
-							"properties": { 
-								"group": { 
+							"properties": {
+								"group": {
 									"minimum": 2,
 									"maximum": 3
 								}

--- a/schemas/Train.json
+++ b/schemas/Train.json
@@ -127,6 +127,13 @@
 							],
 							"uniqueItems": true
 						}
+					},
+					"objects": {
+						"description": "Sub-Baureihen, die ihre nicht definierten Eigenschaften von der darüberliegenden Ebene erben.",
+						"type": "array",
+						"items": {
+							"$ref": "#/properties/data/items"
+						}
 					}
 				},
 				"allOf": [


### PR DESCRIPTION
Mit den JSON-Schemas können z.B. IDEs/Editors wie VS Code Autovervollständigung und Tooltips geben.  
An sich kann man damit auch validieren, dass die Datenstruktur korrekt ist, aber das funktioniert derzeit nur richtig für Dateien ohne `objects`.  
Da setzt es fälschlicherweise voraus, dass sowohl innerhalb als auch außerhalb der Überschreibungen alle nicht-optionalen Attribute verwendet werden.  
Ich bin mir mir nicht sicher, ob/wie sich das mit dem JSON Schema-Standard korrekt umsetzen lässt, der von VS Code z.B. unterstützt wird.
Eine Alternative wäre, das `required` einfach raus zu lassen und so zu erwähnen.