### PR TITLE
Norderweiterung 2

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -1929,6 +1929,89 @@
 					"length": 33
 				}
 			]
+		},
+		{
+			"group": 0,
+			"electrified": true,
+			"maxSpeed": 200,
+			"twistingFactor": 0.1,
+			"objects": [
+				{
+					"start": "EHM",
+					"end": "ERDW",
+					"length": 41
+				},
+				{
+					"start": "ERDW",
+					"end": "EGLO",
+					"length": 9
+				},
+				{
+					"start": "EGLO",
+					"end": "EBILP",
+					"length": 17
+				}
+			]
+		},
+		{
+			"group": 0,
+			"electrified": true,
+			"maxSpeed": 160,
+			"twistingFactor": 0.25,
+			"objects": [
+				{
+					"start": "EBILP",
+					"end": "EHFD",
+					"length": 14
+				},
+				{
+					"start": "EHFD",
+					"end": "HL",
+					"length": 10
+				},
+				{
+					"start": "HL",
+					"end": "HM",
+					"length": 21
+				}
+			]
+		},
+		{
+			"group": 0,
+			"electrified": true,
+			"maxSpeed": 200,
+			"twistingFactor": 0.25,
+			"objects": [
+				{
+					"start": "HM",
+					"end": "HWUN",
+					"length": 43
+				},
+				{
+					"start": "HWUN",
+					"end": "HH",
+					"length": 21
+				}
+			]
+		},
+		{
+			"group": 1,
+			"electrified": false,
+			"name": "Sennebahn",
+			"maxSpeed": 100,
+			"twistingFactor": 0.2,
+			"objects": [
+				{
+					"start": "EPD",
+					"end": "ESHO",
+					"length": 27
+				},
+				{
+					"start": "ESHO",
+					"end": "EBILP",
+					"length": 18
+				}
+			]
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -1771,6 +1771,69 @@
 			"y": -54,
 			"platformLength": 245,
 			"platforms": 5
+		},
+		{
+			"group": 1,
+			"name": "Gütersloh Hbf",
+			"ril100": "EGLO",
+			"x": 272,
+			"y": -28,
+			"platformLength": 405,
+			"platforms": 4
+		},
+		{
+			"group": 1,
+			"name": "Rheda-Wiedenbrück",
+			"ril100": "ERDW",
+			"x": 255,
+			"y": -12,
+			"platformLength": 220,
+			"platforms": 6
+		},
+		{
+			"group": 2,
+			"name": "Bielefeld Hbf",
+			"ril100": "EBIL",
+			"x": 298,
+			"y": -54,
+			"platformLength": 415,
+			"platforms": 7
+		},
+		{
+			"group": 2,
+			"name": "Schloß Holte",
+			"ril100": "ESHO",
+			"x": 306,
+			"y": -31,
+			"platformLength": 120,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Löhne (Westf)",
+			"ril100": "HL",
+			"x": 320,
+			"y": -77,
+			"platformLength": 420,
+			"platforms": 6
+		},
+		{
+			"group": 2,
+			"name": "Minden (Westf)",
+			"ril100": "HM",
+			"x": 352,
+			"y": -93,
+			"platformLength": 415,
+			"platforms": 5
+		},
+		{
+			"group": 2,
+			"name": "Wunstorf",
+			"ril100": "HWUN",
+			"x": 429,
+			"y": -111,
+			"platformLength": 281,
+			"platforms": 8
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -1793,7 +1793,7 @@
 		{
 			"group": 2,
 			"name": "Bielefeld Hbf",
-			"ril100": "EBIL",
+			"ril100": "EBILP",
 			"x": 298,
 			"y": -54,
 			"platformLength": 415,
@@ -1812,10 +1812,19 @@
 			"group": 2,
 			"name": "Löhne (Westf)",
 			"ril100": "HL",
-			"x": 320,
-			"y": -77,
+			"x": 330,
+			"y": -80,
 			"platformLength": 420,
 			"platforms": 6
+		},
+		{
+			"group": 2,
+			"name": "Herford",
+			"ril100": "EHFD",
+			"x": 316,
+			"y": -65,
+			"platformLength": 406,
+			"platforms": 7
 		},
 		{
 			"group": 2,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -179,7 +179,8 @@
 			],
 			"plops": 400000,
 			"objects": [
-				{"stations": ["HH", "HELZ", "HK", "HG", "FKW", "FFU", "NWH"]}
+				{"stations": ["HH", "HELZ", "HK", "HG", "FKW", "FFU", "NWH"]},
+				{"stations": ["HH", "EHFD", "EBILP", "EGLO", "EHM", "EDO", "EBO", "EE", "EDG", "KD", "KK"]}
 			],
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}


### PR DESCRIPTION
Basiert weitestgehend auf #28.
Bahnhöfe:
- Rheda-Wiedenbrück
- Gütersloh
- Schloß-Holte
- Bielefeld Hbf
- Herford
- Löhne (Westf)
- Minden (Westf)
- Wunstorf

Strecken:
- Hamm - Bielefeld - Minden - Hannover
- Paderborn - Bielefeld (Sennebahn)

Aufgaben:
- IC Hannover - Bielefeld - Hamm - Ruhrgebiet - Düsseldorf - Köln (eigentlich geht lt. Wikipedia die Linie _noch_ weiter, aber das wäre doch etwas sehr lang)