### PR TITLE
Add Hameln + Region

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -2190,6 +2190,75 @@
 					"maxSpeed": 20
 				}
 			]
+		},
+		{
+			"group": 0,
+			"electrified": true,
+			"objects": [
+				{
+					"start": "HA",
+					"end": "HLUE",
+					"twistingFactor": 0.4,
+					"length": 37,
+					"maxSpeed": 100
+				},
+				{
+					"start": "HLUE",
+					"end": "HHM",
+					"length": 21,
+					"maxSpeed": 120,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "HHM",
+					"end": "HSPR",
+					"length": 19,
+					"maxSpeed": 120,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "HSPR",
+					"end": "HH",
+					"length": 36,
+					"maxSpeed": 120,
+					"twistingFactor": 0.45
+				}
+			]
+		},
+		{
+			"group": 0,
+			"name": "Weserbahn",
+			"electrified": false,
+			"objects": [
+				{
+					"start": "HELZ",
+					"end": "HHM",
+					"length": 29,
+					"maxSpeed": 120,
+					"twistingFactor": 0.35
+				},
+				{
+					"start": "HHM",
+					"end": "HHSO",
+					"length": 12,
+					"maxSpeed": 120,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "HHSO",
+					"end": "HRIN",
+					"length": 12,
+					"maxSpeed": 120,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "HRIN",
+					"end": "HL",
+					"length": 29,
+					"maxSpeed": 120,
+					"twistingFactor": 0.5
+				}
+			]
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -2015,8 +2015,8 @@
 			"group": 2,
 			"name": "Hessisch Oldendorf",
 			"ril100": "HHSO",
-			"x": 369,
-			"y": -70,
+			"x": 374,
+			"y": -75,
 			"platformLength": 170,
 			"platforms": 2
 		},
@@ -2024,8 +2024,8 @@
 			"group": 2,
 			"name": "Rinteln",
 			"ril100": "HRIN",
-			"x": 341,
-			"y": -74,
+			"x": 351,
+			"y": -84,
 			"platformLength": 198,
 			"platforms": 2
 		}

--- a/Station.json
+++ b/Station.json
@@ -1983,6 +1983,51 @@
 			"ril100": "KKRO",
 			"x": 20,
 			"y": 180
+		},
+		{
+			"group": 2,
+			"name": "Lügde",
+			"ril100": "HLUE",
+			"x": 376,
+			"y": -38,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"group": 2,
+			"name": "Hameln",
+			"ril100": "HHM",
+			"x": 393,
+			"y": -61,
+			"platformLength": 221,
+			"platforms": 6
+		},
+		{
+			"group": 2,
+			"name": "Springe",
+			"ril100": "HSPR",
+			"x": 422,
+			"y": -80,
+			"platformLength": 217,
+			"platforms": 2
+		},
+		{
+			"group": 2,
+			"name": "Hessisch Oldendorf",
+			"ril100": "HHSO",
+			"x": 369,
+			"y": -70,
+			"platformLength": 170,
+			"platforms": 2
+		},
+		{
+			"group": 2,
+			"name": "Rinteln",
+			"ril100": "HRIN",
+			"x": 341,
+			"y": -74,
+			"platformLength": 198,
+			"platforms": 2
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -494,13 +494,13 @@
 			"group": 1,
 			"name": "RB77 von %s nach %s",
 			"descriptions": [
-			  "Bring die Fahrgäste pünktlich von %s nach %s.",
-			  "Fahr mit der Weser-Bahn von %s nach %s."
+				"Bring die Fahrgäste pünktlich von %s nach %s.",
+				"Fahr mit der Weser-Bahn von %s nach %s."
 			],
 			"stations": ["HELZ", "HHM", "HHSO", "HRIN", "HL", "EHFD"],
 			"plops": 200000,
 			"neededCapacity": [
-			  {"name": "passengers", "value": 0}
+				{"name": "passengers", "value": 0}
 			]
 		},
 		{

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -796,6 +796,33 @@
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]
+		},
+		{
+			"group": 1,
+			"name": "S5 Hannover von %s nach %s",
+			"descriptions": [
+				"Bring die Fahrgäste einigermaßen bequem von %s nach %s.",
+				"Fahre den Langläufer von %s nach %s.",
+				"Bring die Fahrgäste pünktlich nach %2$s."
+			],
+			"stations": ["EPD", "HA", "HLUE", "HHM", "HSPR", "HH"],
+			"plops": 200000,
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
+		},
+		{
+			"group": 1,
+			"name": "RB77 von %s nach %s",
+			"descriptions": [
+				"Bring die Fahrgäste pünktlich von %s nach %s.",
+				"Fahr mit der Weser-Bahn von %s nach %s."
+			],
+			"stations": ["HELZ", "HHM", "HHSO", "HRIN", "HL", "EHFD"],
+			"plops": 200000,
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
 		}
 	]
 }


### PR DESCRIPTION
Füllt das Loch zwischen Hannover und Altenbeken.
Bahnhöfe:
- Lügde
- Hameln
- Springe
- Hessisch Oldendorf
- Rinteln

Strecken:
- Hannover - Hameln - Altenbeken
- Elze - Hameln - Löhne

Aufgaben:
- S5 Paderborn - Hannover
- RB77 Elze - Löhne - Herford*

*Eigentlich läuft die Strecke noch nach Bünde, aber ab Dezember 2023 soll die lt. Wikipedia nach Herford verlagert werden.
Und in TC sind wir ja eh schon viel weiter :D