### PR TITLE
Neue Fahrzeuge (vielleicht)

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -157,6 +157,26 @@
 			]
 		},
 		{
+			"id": 4744,
+			"group": 2,
+			"name": "Siemens Desiro ML",
+			"shortcut": "ÖBB 4744",
+			"speed": 160,
+			"weight": 145,
+			"force": 170,
+			"length": 75,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 500000,
+			"operationCosts": 40,
+			"equipments": ["ETCS"],
+			"maxConnectedUnits": 3,
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 259}
+			]
+		},
+		{
 			"id": 23,
 			"group": 2,
 			"name": "Siemens Mireo",

--- a/Train.json
+++ b/Train.json
@@ -177,6 +177,42 @@
 			]
 		},
 		{
+			"id": 428,
+			"group": 2,
+			"name": "Stadler FLIRT 1",
+			"shortcut": "BR 0428",
+			"speed": 160,
+			"weight": 120,
+			"force": 135,
+			"length": 74,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 480000,
+			"operationCosts": 42,
+			"maxConnectedUnits": 2,
+			"capacity": [
+				{"name": "passengers", "value": 219}
+			]
+		},
+		{
+			"id": 3427,
+			"group": 2,
+			"name": "Stadler FLIRT 3XL",
+			"shortcut": "BR 3427",
+			"speed": 160,
+			"weight": 100,
+			"force": 135,
+			"length": 68,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 450000,
+			"operationCosts": 40,
+			"maxConnectedUnits": 3,
+			"capacity": [
+				{"name": "passengers", "value": 190}
+			]
+		},
+		{
 			"id": 1,
 			"group": 2,
 			"name": "Stadler KISS",
@@ -308,6 +344,25 @@
 			"maxConnectedUnits": 3,
 			"capacity": [
 				{"name": "passengers", "value": 110}
+			]
+		},
+		{
+			"id": 643,
+			"group": 2,
+			"name": "Bombardier TALENT",
+			"shortcut": "BR 643",
+			"speed": 120,
+			"weight": 84,
+			"force": 66,
+			"length": 50,
+			"drive": 2,
+			"reliability": 0.95,
+			"cost": 280000,
+			"operationCosts": 60,
+			"maxConnectedUnits": 3,
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 149}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -438,6 +438,20 @@
 			"capacity": []
 		},
 		{
+			"id": 102,
+			"group": 0,
+			"name": "BR 102",
+			"speed": 200,
+			"weight": 88,
+			"force": 275,
+			"length": 18,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 330000,
+			"operationCosts": 100,
+			"capacity": []
+		},
+		{
 			"id": 6,
 			"group": 0,
 			"name": "Bombardier Traxx P160 AC2",
@@ -633,6 +647,23 @@
 			"exchangeTime": 60,
 			"capacity": [
 				{"name": "passengers", "value": 96}
+			]
+		},
+		{
+			"id": 951,
+			"group": 1,
+			"name": "Škoda-Doppelstock-Wagen",
+			"shortcut": "Škoda-Dosto",
+			"speed": 190,
+			"weight": 52,
+			"force": 0,
+			"length": 26,
+			"drive": 0,
+			"reliability": 0.8,
+			"cost": 210000,
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 113}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -157,6 +157,24 @@
 			]
 		},
 		{
+			"id": 440,
+			"group": 2,
+			"name": "Alstom Coradia Continental",
+			"shortcut": "BR 440",
+			"speed": 160,
+			"weight": 112,
+			"force": 140,
+			"length": 58,
+			"drive": 1,
+			"reliability": 0.95,
+			"cost": 450000,
+			"operationCosts": 35,
+			"maxConnectedUnits": 4,
+			"capacity": [
+				{"name": "passengers", "value": 200}
+			]
+		},
+		{
 			"id": 4744,
 			"group": 2,
 			"name": "Siemens Desiro ML",


### PR DESCRIPTION
- Desiro ML
- Stadler FLIRT 1 & 3XL
- Bombardier TALENT 643
- Alstom Coradia Continental (kurz) - Ein paar Daten musste ich mir ausdenken
- BR 102 + Skoda Dosto (als Einzelwagen, nicht fixer Verband, Gewicht geschätzt/geraten)

Zugegeben, ich glaube, es muss nicht alles davon rein, v.a. die FLIRTs und der Desiro ML sind etwas redundant.
Das müssten dafür alle Baureihen sein, mit denen auf meinen Streckenerweiterungen gefahren wird :D