### PR TITLE
Disable linting for YAML for now

### DIFF
--- a/.github/workflows/eclint.yml
+++ b/.github/workflows/eclint.yml
@@ -26,4 +26,6 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          # It sants tabs as indentation, which YAML does not allow
+          VALIDATE_YAML: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
For some reason, the linter wants the workflow YML-files to use tabs for indentation, which is against the YAML standard: https://yaml.org/spec/1.2.2/#61-indentation-spaces