### PR TITLE
Fix Integral maxSpeed

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -334,7 +334,7 @@
 			"group": 2,
 			"name": "Integral",
 			"speed": 140,
-			"weight": 74,
+			"weight": 85,
 			"force": 112,
 			"length": 53,
 			"drive": 2,

--- a/Train.json
+++ b/Train.json
@@ -333,7 +333,7 @@
 			"id": 117,
 			"group": 2,
 			"name": "Integral",
-			"speed": 160,
+			"speed": 140,
 			"weight": 74,
 			"force": 112,
 			"length": 53,


### PR DESCRIPTION
Ich glaube, den Fehler hab ich tatsächlich aus Simutrans übernommen 🥴
Ich hatte irgendwie in Erinnerung, das Ding hätte vMax 160...

Als Masse habe ich außerdem die Leermasse verwendet, was zwar normal glaub ich okay ist, hier aber die ohnehin eigentlich zu hohe Beschleunigung nochmal weiter übertreibt