### PR TITLE
Revert "Doppeltes Saarbrücken entfernt"

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -643,6 +643,15 @@
 			"platforms": 5
 		},
 		{
+			"group": 0,
+			"name": "Saarbrücken Hbf",
+			"ril100": "SSH",
+			"x": 69,
+			"y": 418,
+			"platformLength": 550,
+			"platforms": 10
+		},
+		{
 			"group": 5,
 			"name": "Schafbrücke",
 			"ril100": "SSU",


### PR DESCRIPTION
This reverts commit 7f9f3d2155c7ef04a53d50152c98ff2114456449.