### PR TITLE
MV-Erweiterung

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -6721,6 +6721,88 @@
 					"length": 8
 				}
 			]
+		},
+		{
+			"electrified": true,
+			"group": 2,
+			"maxSpeed": 120,
+			"twistingFactor": 0.1,
+			"objects": [
+				{
+					"start": "WSR",
+					"end": "WMI",
+					"length": 14
+				},
+				{
+					"start": "WMI",
+					"end": "WGW",
+					"length": 16
+				},
+				{
+					"start": "WGW",
+					"end": "WGWS",
+					"length": 2
+				},
+				{
+					"start": "WGWS",
+					"end": "WGKW",
+					"length": 8
+				},
+				{
+					"start": "WGKW",
+					"end": "WZS",
+					"length": 6
+				},
+				{
+					"start": "WZS",
+					"end": "WAK",
+					"length": 16
+				},
+				{
+					"start": "WAK",
+					"end": "WDU",
+					"length": 12
+				},
+				{
+					"start": "WDU",
+					"end": "WFDF",
+					"length": 12
+				},
+				{
+					"start": "WFDF",
+					"end": "WP",
+					"length": 18
+				},
+				{
+					"start": "WP",
+					"end": "WNL",
+					"length": 10
+				},
+				{
+					"start": "WNL",
+					"end": "WPL",
+					"length": 13,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "WPL",
+					"end": "WWAN",
+					"length": 16,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "WWAN",
+					"end": "WWLD",
+					"length": 8,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "WWLD",
+					"end": "WA",
+					"length": 13,
+					"twistingFactor": 0.2
+				}
+			]
 		}
 	]
 }

--- a/Path.json
+++ b/Path.json
@@ -6978,6 +6978,44 @@
 					"twistingFactor": 0.15
 				}
 			]
+		},
+		{
+			"group": 2,
+			"name": "Lloydbahn",
+			"maxSpeed": 160,
+			"twistingFactor": 0.2,
+			"objects": [
+				{
+					"start": "WNT",
+					"end": "WKG",
+					"electrified": true,
+					"length": 14
+				},
+				{
+					"start": "WKG",
+					"end": "WWR",
+					"electrified": true,
+					"length": 21
+				},
+				{
+					"start": "WWR",
+					"end": "WLG",
+					"electrified": true,
+					"length": 25
+				},
+				{
+					"start": "WLG",
+					"end": "WG",
+					"electrified": false,
+					"length": 25
+				},
+				{
+					"start": "WG",
+					"end": "WR",
+					"electrified": true,
+					"length": 33
+				}
+			]
 		}
 	]
 }

--- a/Path.json
+++ b/Path.json
@@ -6981,7 +6981,6 @@
 		},
 		{
 			"group": 2,
-			"name": "Lloydbahn",
 			"maxSpeed": 160,
 			"twistingFactor": 0.2,
 			"objects": [
@@ -7007,15 +7006,26 @@
 					"start": "WLG",
 					"end": "WG",
 					"electrified": false,
-					"length": 25
+					"length": 25,
+					"maxSpeed": 120
 				},
 				{
 					"start": "WG",
-					"end": "WR",
+					"end": "WSN",
 					"electrified": true,
-					"length": 33
+					"length": 17,
+					"maxSpeed": 120
 				}
 			]
+		},
+		{
+			"group": 0,
+			"maxSpeed": 120,
+			"twistingFactor": 0.25,
+			"start": "WG",
+			"end": "WB",
+			"electrified": true,
+			"length": 13
 		}
 	]
 }

--- a/Path.json
+++ b/Path.json
@@ -6869,7 +6869,7 @@
 		{
 			"group": 2,
 			"maxSpeed": 120,
-			"twistingFactor": 160,
+			"twistingFactor": 0.16,
 			"name": "Stettiner Bahn",
 			"objects": [
 				{

--- a/Path.json
+++ b/Path.json
@@ -6803,6 +6803,83 @@
 					"twistingFactor": 0.2
 				}
 			]
+		},
+		{
+			"group": 2,
+			"maxSpeed": 120,
+			"twistingFactor": 160,
+			"name": "Stettiner Bahn",
+			"objects": [
+				{
+					"start": "BL",
+					"end": "BGS",
+					"electrified": true,
+					"length": 4
+				},
+				{
+					"start": "BGS",
+					"end": "BBRN",
+					"electrified": true,
+					"length": 20
+				},
+				{
+					"start": "BBRN",
+					"end": "WE",
+					"electrified": true,
+					"length": 22
+				},
+				{
+					"start": "WE",
+					"end": "WBR",
+					"electrified": true,
+					"length": 4
+				},
+				{
+					"start": "WBR",
+					"end": "WA",
+					"electrified": true,
+					"length": 21
+				},
+				{
+					"start": "WA",
+					"end": "WPS",
+					"electrified": false,
+					"length": 18,
+					"maxSpeed": 60
+				},
+				{
+					"start": "WPS",
+					"end": "WSCN",
+					"electrified": false,
+					"length": 5,
+					"maxSpeed": 50
+				},
+				{
+					"start": "WSCN",
+					"end": "WCW",
+					"electrified": false,
+					"length": 4
+				},
+				{
+					"start": "WCW",
+					"end": "WPE",
+					"electrified": false,
+					"length": 4
+				},
+				{
+					"start": "WPE",
+					"end": "WTA",
+					"electrified": false,
+					"length": 7
+				},
+				{
+					"start": "WTA",
+					"end": "WXT",
+					"electrified": false,
+					"length": 8,
+					"twistingFactor": 0.26
+				}
+			]
 		}
 	]
 }

--- a/Path.json
+++ b/Path.json
@@ -6880,6 +6880,104 @@
 					"twistingFactor": 0.26
 				}
 			]
+		},
+		{
+			"electrified": true,
+			"group": 2,
+			"name": "Berliner Nordbahn",
+			"maxSpeed": 100,
+			"twistingFactor": 0.2,
+			"objects": [
+				{
+					"start": "BGS",
+					"end": "BOR",
+					"length": 31,
+					"maxSpeed": 160
+				},
+				{
+					"start": "BOR",
+					"end": "WLO",
+					"length": 16,
+					"maxSpeed": 160
+				},
+				{
+					"start": "WLO",
+					"end": "WGRA",
+					"length": 12,
+					"maxSpeed": 160
+				},
+				{
+					"start": "WGRA",
+					"end": "WF",
+					"length": 21,
+					"maxSpeed": 160
+				},
+				{
+					"start": "WF",
+					"end": "WNT",
+					"length": 20,
+					"maxSpeed": 160
+				},
+				{
+					"start": "WNT",
+					"end": "WBLS",
+					"length": 14,
+					"twistingFactor": 0.27
+				},
+				{
+					"start": "WBLS",
+					"end": "WBSG",
+					"length": 12,
+					"twistingFactor": 0.27
+				},
+				{
+					"start": "WBSG",
+					"end": "WN",
+					"length": 8,
+					"twistingFactor": 0.27
+				},
+				{
+					"start": "WN",
+					"end": "WATR",
+					"length": 15
+				},
+				{
+					"start": "WATR",
+					"end": "WSE",
+					"length": 16,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "WSE",
+					"end": "WDM",
+					"length": 10,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "WDM",
+					"end": "WGI",
+					"length": 23,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "WGI",
+					"end": "WWT",
+					"length": 8,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "WWT",
+					"end": "WZAR",
+					"length": 6,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "WZAR",
+					"end": "WSR",
+					"length": 7,
+					"twistingFactor": 0.15
+				}
+			]
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -3185,7 +3185,6 @@
 			"platformLength": 135,
 			"platforms": 2
 		},
-
 		{
 			"group": 5,
 			"name": "Heringen (Helme)",
@@ -7481,6 +7480,132 @@
 			"y": 337,
 			"platformLength": 120,
 			"platforms": 2
+		},
+		{
+			"name": "Miltzow",
+			"ril100": "WMI",
+			"group": 2,
+			"x": 912,
+			"y": -403,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Greifswald",
+			"ril100": "WGW",
+			"group": 2,
+			"x": 935,
+			"y": -385,
+			"platformLength": 321,
+			"platforms": 3
+		},
+		{
+			"name": "Greifswald Süd",
+			"ril100": "WGWS",
+			"group": 2,
+			"x": 939,
+			"y": -383,
+			"platformLength": 156,
+			"platforms": 2
+		},
+		{
+			"name": "Groß Kiesow",
+			"ril100": "WGKW",
+			"group": 2,
+			"x": 950,
+			"y": -372,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Züssow",
+			"ril100": "WZS",
+			"group": 2,
+			"x": 959,
+			"y": -366,
+			"platformLength": 321,
+			"platforms": 2
+		},
+		{
+			"name": "Anklam",
+			"ril100": "WAK",
+			"group": 2,
+			"x": 980,
+			"y": -346,
+			"platformLength": 321,
+			"platforms": 2
+		},
+		{
+			"name": "Ducherow",
+			"ril100": "WDU",
+			"group": 2,
+			"x": 993,
+			"y": -331,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Ferdinandshof",
+			"ril100": "WFDF",
+			"group": 2,
+			"x": 1005,
+			"y": -314,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Pasewalk",
+			"ril100": "WP",
+			"group": 2,
+			"x": 1019,
+			"y": -290,
+			"platformLength": 331,
+			"platforms": 4
+		},
+		{
+			"name": "Nechlin",
+			"ril100": "WNL",
+			"group": 5,
+			"x": 1008,
+			"y": -277,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Prenzlau",
+			"ril100": "WPL",
+			"group": 2,
+			"x": 1003,
+			"y": -257,
+			"platformLength": 320,
+			"platforms": 3
+		},
+		{
+			"name": "Warnitz (Uckerm)",
+			"ril100": "WWAN",
+			"group": 2,
+			"x": 1004,
+			"y": -234,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Wilmersdorf (Kr Angermünde)",
+			"ril100": "WWLD",
+			"group": 2,
+			"x": 1006,
+			"y": -223,
+			"platformLength": 155,
+			"platforms": 3
+		},
+		{
+			"name": "Angermünde",
+			"ril100": "WA",
+			"group": 1,
+			"x": 1020,
+			"y": -207,
+			"platformLength": 321,
+			"platforms": 5
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -7494,8 +7494,8 @@
 			"name": "Greifswald",
 			"ril100": "WGW",
 			"group": 2,
-			"x": 935,
-			"y": -385,
+			"x": 932,
+			"y": -388,
 			"platformLength": 321,
 			"platforms": 3
 		},
@@ -7503,8 +7503,8 @@
 			"name": "Greifswald Süd",
 			"ril100": "WGWS",
 			"group": 2,
-			"x": 939,
-			"y": -383,
+			"x": 941,
+			"y": -381,
 			"platformLength": 156,
 			"platforms": 2
 		},
@@ -7611,8 +7611,8 @@
 			"name": "Berlin-Gesundbrunnen",
 			"ril100": "BGS",
 			"group": 1,
-			"x": 938,
-			"y": -129,
+			"x": 942,
+			"y": -134,
 			"platformLength": 405,
 			"platforms": 10
 		},
@@ -7638,8 +7638,8 @@
 			"name": "Britz",
 			"ril100": "WBR",
 			"group": 2,
-			"x": 996,
-			"y": -183,
+			"x": 1000,
+			"y": -188,
 			"platformLength": 140,
 			"platforms": 2
 		},
@@ -7647,8 +7647,8 @@
 			"name": "Passow (Uckermark)",
 			"ril100": "WPS",
 			"group": 2,
-			"x": 1035,
-			"y": -229,
+			"x": 1032,
+			"y": -226,
 			"platformLength": 104,
 			"platforms": 1
 		},
@@ -7656,8 +7656,8 @@
 			"name": "Schönow (Uckermark)",
 			"ril100": "WSCN",
 			"group": 5,
-			"x": 1042,
-			"y": -235,
+			"x": 1040,
+			"y": -233,
 			"platformLength": 124,
 			"platforms": 1
 		},
@@ -7674,8 +7674,8 @@
 			"name": "Petershagen (Uckermark)",
 			"ril100": "WPE",
 			"group": 2,
-			"x": 1055,
-			"y": -244,
+			"x": 1058,
+			"y": -247,
 			"platformLength": 118,
 			"platforms": 1
 		},
@@ -7683,8 +7683,8 @@
 			"name": "Tantow",
 			"ril100": "WTA",
 			"group": 2,
-			"x": 1068,
-			"y": -249,
+			"x": 1071,
+			"y": -252,
 			"platformLength": 100,
 			"platforms": 2
 		},
@@ -7692,8 +7692,8 @@
 			"name": "Tantow Grenze",
 			"ril100": "WXT",
 			"group": 3,
-			"x": 1077,
-			"y": -258
+			"x": 1080,
+			"y": -263
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -7820,6 +7820,42 @@
 			"y": -410,
 			"platformLength": 143,
 			"platforms": 1
+		},
+		{
+			"name": "Kratzeburg",
+			"ril100": "WKG",
+			"group": 2,
+			"x": 877,
+			"y": -275,
+			"platformLength": 140,
+			"platforms": 1
+		},
+		{
+			"name": "Waren (Müritz)",
+			"ril100": "WWR",
+			"group": 1,
+			"x": 842,
+			"y": -291,
+			"platformLength": 345,
+			"platforms": 3
+		},
+		{
+			"name": "Langhagen",
+			"ril100": "WLG",
+			"group": 2,
+			"x": 807,
+			"y": -317,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Güstrow",
+			"ril100": "WG",
+			"group": 1,
+			"x": 773,
+			"y": -337,
+			"platformLength": 298,
+			"platforms": 4
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -7606,6 +7606,94 @@
 			"y": -207,
 			"platformLength": 321,
 			"platforms": 5
+		},
+		{
+			"name": "Berlin-Gesundbrunnen",
+			"ril100": "BGS",
+			"group": 1,
+			"x": 938,
+			"y": -129,
+			"platformLength": 405,
+			"platforms": 10
+		},
+		{
+			"name": "Bernau (b Berlin)",
+			"ril100": "BBRN",
+			"group": 1,
+			"x": 966,
+			"y": -150,
+			"platformLength": 293,
+			"platforms": 4
+		},
+		{
+			"name": "Eberswalde Hbf",
+			"ril100": "WE",
+			"group": 1,
+			"x": 993,
+			"y": -177,
+			"platformLength": 320,
+			"platforms": 5
+		},
+		{
+			"name": "Britz",
+			"ril100": "WBR",
+			"group": 2,
+			"x": 996,
+			"y": -183,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"name": "Passow (Uckermark)",
+			"ril100": "WPS",
+			"group": 2,
+			"x": 1035,
+			"y": -229,
+			"platformLength": 104,
+			"platforms": 1
+		},
+		{
+			"name": "Schönow (Uckermark)",
+			"ril100": "WSCN",
+			"group": 5,
+			"x": 1042,
+			"y": -235,
+			"platformLength": 124,
+			"platforms": 1
+		},
+		{
+			"name": "Casekow",
+			"ril100": "WCW",
+			"group": 2,
+			"x": 1049,
+			"y": -240,
+			"platformLength": 116,
+			"platforms": 1
+		},
+		{
+			"name": "Petershagen (Uckermark)",
+			"ril100": "WPE",
+			"group": 2,
+			"x": 1055,
+			"y": -244,
+			"platformLength": 118,
+			"platforms": 1
+		},
+		{
+			"name": "Tantow",
+			"ril100": "WTA",
+			"group": 2,
+			"x": 1068,
+			"y": -249,
+			"platformLength": 100,
+			"platforms": 2
+		},
+		{
+			"name": "Tantow Grenze",
+			"ril100": "WXT",
+			"group": 3,
+			"x": 1077,
+			"y": -258
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -7694,6 +7694,132 @@
 			"group": 3,
 			"x": 1080,
 			"y": -263
+		},
+		{
+			"name": "Oranienburg",
+			"ril100": "BOR",
+			"group": 1,
+			"x": 919,
+			"y": -163,
+			"platformLength": 277,
+			"platforms": 6
+		},
+		{
+			"name": "Löwenberg (Mark)",
+			"ril100": "WLO",
+			"group": 2,
+			"x": 911,
+			"y": -187,
+			"platformLength": 140,
+			"platforms": 3
+		},
+		{
+			"name": "Gransee",
+			"ril100": "WGRA",
+			"group": 2,
+			"x": 908,
+			"y": -204,
+			"platformLength": 210,
+			"platforms": 2
+		},
+		{
+			"name": "Fürstenberg (Havel)",
+			"ril100": "WF",
+			"group": 2,
+			"x": 904,
+			"y": -235,
+			"platformLength": 224,
+			"platforms": 3
+		},
+		{
+			"name": "Neustrelitz Hbf",
+			"ril100": "WNT",
+			"group": 2,
+			"x": 895,
+			"y": -264,
+			"platformLength": 326,
+			"platforms": 4
+		},
+		{
+			"name": "Blankensee (Meckl)",
+			"ril100": "WBLS",
+			"group": 2,
+			"x": 921,
+			"y": -272,
+			"platformLength": 201,
+			"platforms": 2
+		},
+		{
+			"name": "Burg Stargard (Meckl)",
+			"ril100": "WBSG",
+			"group": 2,
+			"x": 926,
+			"y": -287,
+			"platformLength": 204,
+			"platforms": 2
+		},
+		{
+			"name": "Neubrandenburg",
+			"ril100": "WN",
+			"group": 2,
+			"x": 920,
+			"y": -297,
+			"platformLength": 140,
+			"platforms": 4
+		},
+		{
+			"name": "Altentreptow",
+			"ril100": "WATR",
+			"group": 2,
+			"x": 918,
+			"y": -319,
+			"platformLength": 150,
+			"platforms": 2
+		},
+		{
+			"name": "Sternfeld",
+			"ril100": "WSE",
+			"group": 2,
+			"x": 905,
+			"y": -341,
+			"platformLength": 154,
+			"platforms": 2
+		},
+		{
+			"name": "Demmin",
+			"ril100": "WDM",
+			"group": 2,
+			"x": 892,
+			"y": -354,
+			"platformLength": 150,
+			"platforms": 2
+		},
+		{
+			"name": "Grimmen",
+			"ril100": "WGI",
+			"group": 2,
+			"x": 890,
+			"y": -388,
+			"platformLength": 175,
+			"platforms": 2
+		},
+		{
+			"name": "Wittenhagen",
+			"ril100": "WWT",
+			"group": 2,
+			"x": 893,
+			"y": -401,
+			"platformLength": 148,
+			"platforms": 1
+		},
+		{
+			"name": "Zarrendorf",
+			"ril100": "WZAR",
+			"group": 2,
+			"x": 896,
+			"y": -410,
+			"platformLength": 143,
+			"platforms": 1
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -652,6 +652,41 @@
 		},
 		{
 			"group": 1,
+			"name": "RE von %s nach %s",
+			"descriptions": [
+				"Bringe den Regionalexpress durch Mecklenburg-Vorpommern von %s nach %s.",
+				"Bring die Fahrgäste sicher und pünktlich nach %2$s."
+			],
+			"plops": 300000,
+			"objects": [
+				{
+					"name": "Hanse-Express von %s nach %s",
+					"stations": ["AH", "AMUE", "ABCH", "WBZ", "WBRH", "WHL", "WS", "WK", "WBL", "WB", "WSN", "WR"]
+				},
+				{
+					"name": "RE3 von %s nach %s",
+					"stations": ["WSR", "WMI", "WGW", "WGWS", "WGWK", "WZS", "WAK", "WDU", "WFDF", "WP", "WNL", "WPL", "WWAN", "WWLD", "WA", "WBR", "WE", "BBRN", "BGS", "BL"],
+					"descriptions": [
+						"Bringe den Langläufer quer durch drei Bundesländer."
+					],
+					"plops": 400000
+				},
+				{
+					"name": "RE7 von %s nach %s",
+					"stations": ["WSR", "WMI", "WGW"],
+					"plops": 160000
+				},
+				{
+					"name": "RE9 von %s nach %s",
+					"stations": ["WR", "WRV", "WRI", "WBUH", "WV", "WSRB", "WST", "WSRR", "WBG", "WBI"]
+				}
+			],
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
+		},
+		{
+			"group": 1,
 			"name": "RB89 von %s nach %s",
 			"descriptions": [
 				"Bring die Ems-Börde-Bahn pünktlich von %s nach %s."

--- a/Train.json
+++ b/Train.json
@@ -503,6 +503,19 @@
 			"operationCosts": 120
 		},
 		{
+			"id": 112,
+			"group": 0,
+			"name": "BR 112",
+			"speed": 160,
+			"weight": 83,
+			"force": 226,
+			"length": 17,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 230000,
+			"operationCosts": 80
+		},
+		{
 			"id": 6,
 			"group": 0,
 			"name": "Bombardier Traxx P160 AC2",


### PR DESCRIPTION
Fügt Stralsund - Berlin (sowohl via Greifswald, etc., als auch via Neustrelitz) hinzu, sowie eine Variante der Strecke zw. Neustrelitz und Rostock.
Dazu neue REs für MV und Berlin/Brandenburg und die BR112.