### PR TITLE
Flugersatzverkehr

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -7917,7 +7917,7 @@
 			"twistingFactor": 0.2,
 			"objects": [
 				{
-					"start": "WWO", 
+					"start": "WWO",
 					"end": "WTH",
 					"length": 9
 				},
@@ -7956,6 +7956,25 @@
 					"end": "XPSM",
 					"length": 4,
 					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"maxSpeed": 100,
+			"twistingFactor": 0.3,
+			"objects": [
+				{
+					"start": "BL",
+					"end": "BFBI",
+					"length": 36
+				},
+				{
+					"start": "BFBI",
+					"end": "BBF",
+					"length": 8,
+					"twistingFactor": 0.24
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -9022,6 +9022,15 @@
 			"y": -349,
 			"platformLength": 126,
 			"platforms": 2
+		},
+		{
+			"name": "Berlin Flughafen BER",
+			"ril100": "BFBI",
+			"group": 1,
+			"x": 954,
+			"y": -99,
+			"platformLength": 405,
+			"platforms": 6
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1262,8 +1262,12 @@
 			"name": "Flugersatzverkehr von %s nach %s",
 			"descriptions": [
 				"Wegen zu langer Warteschlangen am Check-In fährt ein Ersatzzug die Fluggäste von %s nach %s.",
-				"Weil mal wieder Pilot*innen streiken, brauchen die Airlines Ersatz.",
-				"Bringe die Flug... Fahrgäste im angemessenen Tempo von %s nach %s"
+				"Weil mal wieder Pilot*innen streiken, brauchen die Airlines schnell Ersatz.",
+				"Weil mal wieder Fluglots*innen streiken, brauchen die Airlines schnell Ersatz.",
+				"Weil mal wieder die Flugzeuge streiken, brauchen die Airlines schnell Ersatz.",
+				"Weil mal wieder das Bodenpersonal streikt, brauchen die Airlines schnell Ersatz.",
+				"Eine Airline möchte eine Zugfahrt von %s nach %s anbieten, um sich grün zu waschen.",
+				"Bringe ein*e Politiker*in medienwirksam zum Klimagipfel nach %s."
 			],
 			"plops": 500000,
 			"plopDifference": 8,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1256,6 +1256,25 @@
 				{"name": "castor", "value": 10}
 			],
 			"neededCapacityDifference": 3
+		},
+		{
+			"group": 0,
+			"name": "Flugersatzverkehr von %s nach %s",
+			"descriptions": [
+				"Wegen zu langer Warteschlangen am Check-In fährt ein Ersatzzug die Fluggäste von %s nach %s.",
+				"Weil mal wieder Pilot*innen streiken, brauchen die Airlines Ersatz.",
+				"Bringe die Flug... Fahrgäste im angemessenen Tempo von %s nach %s"
+			],
+			"plops": 500000,
+			"plopDifference": 8,
+			"objects": [
+				{"stations": ["ALB", "BFBI"]},
+				{"stations": ["ALB", "FFLF"]},
+				{"stations": ["BFBI", "FFLF"]}
+			],
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
 		}
 	]
 }


### PR DESCRIPTION
Fügt den Bahnhof Berlin Flughafen BER hinzu und Direktvergaben zwischen den drei Flughäfen.