### PR TITLE
Erweiterung Train.json mit BR 420

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -122,6 +122,23 @@
 			]
 		},
 		{
+			"id": 420,
+			"group": 2,
+			"name": "BR 420",
+			"speed": 120,
+			"weight": 129,
+			"force": 140,
+			"length": 68,
+			"drive": 1,
+			"reliability": 0.85,
+			"cost": 450000,
+			"operationCosts": 60,
+			"maxConnectedUnits": 3,
+			"capacity": [
+				{"name": "passengers", "value": 192}
+			]
+		},
+		{
 			"id": 9,
 			"group": 2,
 			"name": "BR 425",


### PR DESCRIPTION
Naja, die Baureihe 420 ist zwar alt (deswegen auch etwas höhere Instandhaltungskosten), aber mMn. trotzdem dürfte es im Spiel nicht fehlen.