### PR TITLE
Hauptbahn & Nebenbahn im Oberland Fix

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -5216,21 +5216,21 @@
 					"length": 9,
 					"twistingFactor": 0.3,
 					"maxSpeed": 160,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MSN",
 					"end": "MDS",
 					"length": 9,
 					"twistingFactor": 0.2,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MDS",
 					"end": "MHO",
 					"length": 18,
 					"twistingFactor": 0.2,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MHO",
@@ -5239,7 +5239,7 @@
 					"maxSpeed": 100,
 					"twistingFactor": 0.23,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				},
 				{
 					"start": "MSFL",
@@ -5248,7 +5248,7 @@
 					"maxSpeed": 100,
 					"twistingFactor": 0.1,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				},
 				{
 					"start": "MBT",
@@ -5257,7 +5257,7 @@
 					"maxSpeed": 100,
 					"twistingFactor": 0.15,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				}
 			]
 		},
@@ -5273,7 +5273,7 @@
 					"maxSpeed": 120,
 					"twistingFactor": 0.4,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				},
 				{
 					"start": "MMIB",
@@ -5282,7 +5282,7 @@
 					"maxSpeed": 100,
 					"twistingFactor": 0.1,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				},
 				{
 					"start": "MSCS",
@@ -5291,7 +5291,7 @@
 					"maxSpeed": 60,
 					"twistingFactor": 0.6,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				}
 			]
 		},
@@ -5307,7 +5307,7 @@
 					"maxSpeed": 80,
 					"twistingFactor": 0.3,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				},
 				{
 					"start": "MGMD",
@@ -5316,7 +5316,7 @@
 					"maxSpeed": 80,
 					"twistingFactor": 0.25,
 					"electrified": false,
-					"group": 0
+					"group": 1
 				}
 			]
 		},


### PR DESCRIPTION
In der jetzigen version, habe ich ausversehen die strecken nach Holzkirchen als Hauptbahn betitelt, aber ich vermute dass die strecke zwischen München Hbf und Holzkirchen eigentlich die hauptbahn ist und alle Strecken hinter Holzkirchen Richtung Oberland (MTE, MBZ & MLG) nur Nebenbahnen sind.