### PR TITLE
BRB Netz Chiemgau-Inntal

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -5262,6 +5262,57 @@
 			]
 		},
 		{
+			"name": "Mangfalltalbahn"
+			"maxSpeed": 120,
+			"electrified": true,
+			"group": 1,
+			"objects": [
+				{
+					"start": "MHO",
+					"end": "MKZ",
+					"length": 6,
+					"maxSpeed": 120,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "MKZ",
+					"end": "MBRM",
+					"length": 14,
+					"maxSpeed": 120,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "MBRM",
+					"end": "MBAI",
+					"length": 7,
+					"twistingFactor": 0.15,
+					"group": 1
+				},
+				{
+					"start": "MBAI",
+					"end": "MKMR",
+					"length": 5,
+					"twistingFactor": 0.5,
+					"group": 1
+				},
+				{
+					"start": "MBAI",
+					"end": "MKMR",
+					"length": 5,
+					"twistingFactor": 0.15,
+					"group": 1
+				},
+				{
+					"start": "MKMR",
+					"end": "MRO",
+					"length": 5,
+					"twistingFactor": 0.45,
+					"group": 1
+				},
+		
+			]
+		},
+		{
 			"maxSpeed": 120,
 			"electrified": false,
 			"group": 1,

--- a/Path.json
+++ b/Path.json
@@ -5262,7 +5262,7 @@
 			]
 		},
 		{
-			"name": "Mangfalltalbahn"
+			"name": "Mangfalltalbahn",
 			"maxSpeed": 120,
 			"electrified": true,
 			"group": 1,

--- a/Path.json
+++ b/Path.json
@@ -5265,7 +5265,7 @@
 			"name": "Mangfalltalbahn",
 			"maxSpeed": 120,
 			"electrified": true,
-			"group": 1,
+			"group": 0,
 			"objects": [
 				{
 					"start": "MHO",
@@ -5286,28 +5286,28 @@
 					"end": "MBAI",
 					"length": 7,
 					"twistingFactor": 0.15,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MBAI",
 					"end": "MKMR",
 					"length": 5,
 					"twistingFactor": 0.5,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MBAI",
 					"end": "MKMR",
 					"length": 5,
 					"twistingFactor": 0.15,
-					"group": 1
+					"group": 0
 				},
 				{
 					"start": "MKMR",
 					"end": "MRO",
 					"length": 5,
 					"twistingFactor": 0.45,
-					"group": 1
+					"group": 0
 				}
 			]
 		},

--- a/Path.json
+++ b/Path.json
@@ -5308,8 +5308,7 @@
 					"length": 5,
 					"twistingFactor": 0.45,
 					"group": 1
-				},
-		
+				}
 			]
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -5948,6 +5948,42 @@
 		},
 		{
 			"group": 2,
+			"name": "Kreuzstraße",
+			"ril100": "MKZ",
+			"x": 690,
+			"y": 632,
+			"platformLength": 145,
+			"platforms": 3
+		},
+		{
+			"group": 5,
+			"name": "Bruckmühl",
+			"ril100": "MBRM",
+			"x": 704,
+			"y": 635,
+			"platformLength": 130,
+			"platforms": 2
+		},
+		{
+			"group": 2,
+			"name": "Bad Aibling",
+			"ril100": "MBAI",
+			"x": 713,
+			"y": 638,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Kolbermoor",
+			"ril100": "MKMR",
+			"x": 730,
+			"y": 643,
+			"platformLength": 140,
+			"platforms": 2
+		},
+		{
+			"group": 2,
 			"name": "Schaftlach",
 			"ril100": "MSFL",
 			"x": 675,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -373,6 +373,7 @@
 				{"stations": ["MH", "MSN", "MHO", "MMIB", "MSCS", "MBZ"]},
 				{"stations": ["MH", "MSN", "MHO", "MMIB", "MSCS"]}
 			],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]
@@ -390,6 +391,7 @@
 				{"stations": ["MHO", "MKZ", "MBRM", "MBAI", "MKMR", "MRO"]},
 				{"stations": ["MH", "MSN", "MDS"]}
 			],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]
@@ -407,6 +409,7 @@
 				{"stations": ["MH", "MRO"]},
 				{"stations": ["MH", "MRO", "MBEF", "MPR", "MUS", "MTS"]}
 			],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]
@@ -425,6 +428,7 @@
 				{"stations": ["MTS", "MTO", "MFL", "XASB"]},
 				{"stations": ["MPR", "MUS", "MTS", "MTO", "MFL", "XASB"]}
 			],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]
@@ -437,6 +441,7 @@
 			],
 			"plops": 300000,
 			"stations": [ "MHO", "MDS", "MH", "MMAM"],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}
 			]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -370,7 +370,60 @@
 			"objects": [
 				{"stations": ["MH", "MSN", "MHO", "MSFL", "MBT", "MLG"]},
 				{"stations": ["MH", "MSN", "MHO", "MSFL", "MGMD", "MTE"]},
-				{"stations": ["MH", "MSN", "MHO", "MMIB", "MSCS", "MBZ"]}
+				{"stations": ["MH", "MSN", "MHO", "MMIB", "MSCS", "MBZ"]},
+				{"stations": ["MH", "MSN", "MHO", "MMIB", "MSCS"]}
+			],
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
+		},
+		{
+			"group": 1,
+			"name": "BRB Chiemgau-Inntal von %s nach %s",
+			"descriptions": [
+				"Du fährst die BRB Chiemgau-Inntal von %s nach %s."
+			],
+			"plops": 300000,
+			"objects": [
+				{"stations": ["MH", "MSN", "MDS", "MHO"]},
+				{"stations": ["MH", "MSN", "MDS", "MHO", "MKZ", "MBRM", "MBAI", "MKMR", "MRO"]},
+				{"stations": ["MHO", "MKZ", "MBRM", "MBAI", "MKMR", "MRO"]},
+				{"stations": ["MH", "MSN", "MDS"]}
+			],
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
+		},
+		{
+			"group": 1,
+			"name": "BRB Chiemgau-Inntal (RE 5) von %s nach %s",
+			"descriptions": [
+				"Die BEG schreibt das Chiemgau-Inntal Netz aus. Deine Fahrt führt von %s nach %s",
+				"Um dem bestellten Einsatz gerecht zu werden, müssen Fahrgäste von %s nach %s im Netz Chiemgau-Inntal befördert werden."
+			],
+			"plops": 300000,
+			"objects": [
+				{"stations": ["MH", "MRO", "MBEF", "MPR", "MUS", "MTS", "MTO", "MFL", "XASB"]},
+				{"stations": ["MH", "MRO"]},
+				{"stations": ["MH", "MRO", "MBEF", "MPR", "MUS", "MTS"]}
+			],
+			"neededCapacity": [
+				{"name": "passengers", "value": 0}
+			]
+		},
+		{
+			"group": 0,
+			"name": "Pendelzug RE 5 von %s nach %s",
+			"descriptions": [
+				"Wegen Bauarbeiten wurde ein Streckenabschnitt gesperrt. Fahre einen Pendelzug von %s nach %s.",
+				"Ein Polizeieinsatz hat den Bahnverkehr zum erliegen gebracht. Ein SEV für den Streckenabschnitt wurde eingerichtet. Fahre einen Pendelzug zwischen %s und %s."
+			],
+			"plops": 320000,
+			"objects": [
+				{"stations": ["MH", "MRO", "MBEF", "MPR"]},
+				{"stations": ["MH", "MRO"]},
+				{"stations": ["MTS", "MTO", "MFL", "XASB"]},
+				{"stations": ["MPR", "MUS", "MTS", "MTO", "MFL", "XASB"]}
 			],
 			"neededCapacity": [
 				{"name": "passengers", "value": 0}

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -364,7 +364,7 @@
 			"group": 1,
 			"name": "BRB Oberland von %s nach %s",
 			"descriptions": [
-				"Fahre durch das Bayerische Oberland. Die Strecke die angeboten wird, ist die von %s nach %s. Gute Reise!"
+				"Fahre durch das Bayerische Oberland. Du wirst gebeten von %s nach %s zu fahren. Gute Reise!"
 			],
 			"plops": 300000,
 			"objects": [


### PR DESCRIPTION
Ich war wieder mal hart am arbeiten. Ich habe folgendes hinzugefügt:
- Mangfalltalbahn (Holzkirchen <> Rosenheim)
- Neue Aufgaben (RE 5: München Hbf <> Salzburg | RE 5 Pendelzug: München Hbf <> Prien am Chiemsee / Prien am Chiemsee <> Salzburg Hbf / München Hbf <> Rosenheim / Traunstein <> Salzburg | RB 58: (München Hbf - Deisenhofen -) Holzkirchen - Rosenheim u.v.m)
- 1 Neuer Umlauf im Oberland (München Hbf - Holzkirchen - Miesbach - Schliersee)