### PR TITLE
Speisewagen

### DIFF
--- a/Capacity.json
+++ b/Capacity.json
@@ -11,6 +11,15 @@
 			"exchangeFactor": 1
 		},
 		{
+			"idString": "bistroseats",
+			"name": "Speiseplätze",
+			"needsPlatform": true,
+			"unit": "",
+			"unitMass": 0.07,
+			"emoji": "🍽",
+			"exchangeFactor": 0.5
+		},
+		{
 			"idString": "beds",
 			"name": "Betten",
 			"needsPlatform": true,

--- a/Capacity.json
+++ b/Capacity.json
@@ -17,7 +17,7 @@
 			"unit": "",
 			"unitMass": 0.07,
 			"emoji": "🍽",
-			"exchangeFactor": 0.5
+			"exchangeFactor": 0.05
 		},
 		{
 			"idString": "beds",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1988,6 +1988,22 @@
 				{ "name": "bistroseats", "value": 0 },
 				{ "name": "beds", "value": 0 }
 			]
+		},
+		{
+			"group": 0,
+			"name": "McTrain von %s nach %s",
+			"descriptions": [
+				"Bring die hunrigen Fahrgäste in die andere Ecke des Landes.",
+				"Fahre den Zug zwischen Alpen und Nordsee.",
+				"Fahr mit dem Fastfood-Express nach %2$s."
+			],
+			"plops": 460000,
+			"stations": [ "AH", "EDO", "KD", "KK", "KKO", "FMZ", "FF", "NWH", "NN", "MA", "MH" ],
+            "pathSuggestion": [ "AH","AHAR", "ABLZ", "AROG", "HB", "HO", "EMST", "EHM", "EDO", "EBO", "EE", "EDG", "KD", "KK", "KKAS", "KB", "KKO", "FBGK", "FMZ", "FFLF", "FF", "FH", "NAH", "NLO", "NGM", "NWH", "NRTD", "NF", "NN", "MDT", "MA", "MOZ", "MH" ],
+			"neededCapacity": [
+				{ "name": "bistroseats", "value": 60 },
+				{ "name": "passengers", "value": 0 }
+			]
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -25,7 +25,8 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "passengers", "value": 0 }
+				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 }
 			]
 		},
 		{
@@ -67,7 +68,8 @@
 			"plops": 560000,
 			"stations": [ "FD", "FFLF", "FLIS", "FMT", "KSIB", "KK", "KD", "EDG", "EE", "EBO", "EDO", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FFU", "NWH", "NN", "MH" ],
 			"neededCapacity": [
-				{ "name": "passengers", "value": 0 }
+				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 }
 			],
 			"pathSuggestion": [ "FD", "FF", "FFLF", "FLIS", "FMT", "KSIB", "KT", "KK", "KD", "EDG", "EE", "EBO", "EDO", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FFU", "NBN", "NRB", "NWH", "NRTD", "NF", "NN", "MIH", "MH" ]
 		},
@@ -160,7 +162,8 @@
 			],
 			"stations": [ "KK", "KSO", "KW", "EHG", "EDO", "EHM", "EGLO", "EBILP", "EHFD", "HH", "HBS", "LM", "LK", "LH", "LL", "DR", "DH" ],
 			"neededCapacity": [
-				{ "name": "passengers", "value": 0 }
+				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 }
 			],
 			"plops": 396000,
 			"group": 1,
@@ -239,7 +242,8 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "passengers", "value": 0 }
+				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 }
 			]
 		},
 		{
@@ -1432,7 +1436,8 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "passengers", "value": 0 }
+				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 }
 			]
 		},
 		{
@@ -1980,6 +1985,7 @@
 			],
 			"neededCapacity": [
 				{ "name": "passengers", "value": 0 },
+				{ "name": "bistroseats", "value": 0 },
 				{ "name": "beds", "value": 0 }
 			]
 		}

--- a/Train.json
+++ b/Train.json
@@ -18,7 +18,8 @@
 			"equipments": ["ETCS", "CH"],
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "passengers", "value": 703}
+				{"name": "passengers", "value": 703},
+				{"name": "bistroseats", "value": 24 }
 			]
 		},
 		{
@@ -38,7 +39,8 @@
 			"equipments": ["ETCS", "KRM", "FR", "NL"],
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "passengers", "value": 460}
+				{"name": "passengers", "value": 460},
+				{"name": "bistroseats", "value": 16 }
 			]
 		},
 		{
@@ -58,7 +60,8 @@
 			"maxConnectedUnits": 2,
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "passengers", "value": 444}
+				{"name": "passengers", "value": 444},
+				{"name": "bistroseats", "value": 16 }
 			]
 		},
 		{
@@ -78,7 +81,8 @@
 			"maxConnectedUnits": 1,
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "passengers", "value": 918}
+				{"name": "passengers", "value": 918},
+				{"name": "bistroseats", "value": 22 }
 			]
 		},
 		{
@@ -99,7 +103,8 @@
 			"equipments": ["CH"],
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "passengers", "value": 195}
+				{"name": "passengers", "value": 195},
+				{"name": "bistroseats", "value": 2 }
 			]
 		},
 		{
@@ -878,6 +883,23 @@
 			"exchangeTime": 180,
 			"capacity": [
 				{"name": "beds", "value": 30}
+			]
+		},
+		{
+			"id": 37,
+			"group": 1,
+			"name": "IC-Speisewagen",
+			"shortcut": "ARmz211.0",
+			"speed": 200,
+			"weight": 48,
+			"force": 0,
+			"length": 28,
+			"drive": 0,
+			"reliability": 0.9,
+			"cost": 220000,
+			"exchangeTime": 180,
+			"capacity": [
+				{"name": "bistroseats", "value": 18}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -903,6 +903,40 @@
 			]
 		},
 		{
+			"id": 38,
+			"group": 1,
+			"name": "Reko-Speisewagen",
+			"shortcut": "WRge542",
+			"speed": 140,
+			"weight": 31,
+			"force": 0,
+			"length": 19,
+			"drive": 0,
+			"reliability": 0.9,
+			"cost": 90000,
+			"exchangeTime": 180,
+			"capacity": [
+				{"name": "bistroseats", "value": 24 }
+			]
+		},
+		{
+			"id": 39,
+			"group": 1,
+			"name": "Y-Speisewagen",
+			"shortcut": "WRme",
+			"speed": 160,
+			"weight": 43,
+			"force": 0,
+			"length": 26,
+			"drive": 0,
+			"reliability": 0.9,
+			"cost": 180000,
+			"exchangeTime": 180,
+			"capacity": [
+				{"name": "bistroseats", "value": 42 }
+			]
+		},
+		{
 			"id": 11,
 			"group": 1,
 			"name": "n-Wagen",


### PR DESCRIPTION
- +Cargotype: Bewirtungsplätze in Speisewagen/Buffetwagen/Bordbistro
- +3 passende Wagontypen
- +Ausschreibung McTrain
- Bewirtungsplätze in ICEs hinzugefügt
- einige Ausschreibungen für ICE/EC/IC um Anforderung Bewirtungsplätze erweitert

Anmerkung: 
- Beim ICE1 wurden vom WSmz nur die 24 Restaurantsitzplätze berücksichtigt, nicht die Stehplätze im Bistro. 
- Bistrokapazität TGV 2N2 ist mir nicht bekannt.
- fortlaufende ids 37,38,39 verwendet (stand letzter pull)
