### PR TITLE
Billige Rekowagen für den Start

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -1023,6 +1023,40 @@
 			]
 		},
 		{
+			"id": 41,
+			"group": 1,
+			"name": "Reko-Wagen 3-achs Tragl.",
+			"shortcut": "Baagtr",
+			"speed": 90,
+			"weight": 18,
+			"force": 0,
+			"length": 13,
+			"drive": 0,
+			"reliability": 0.5,
+			"cost": 22000,
+			"exchangeTime": 120,
+			"capacity": [
+				{"name": "passengers", "value": 32}
+			]
+		},
+		{
+			"id": 42,
+			"group": 1,
+			"name": "Reko-Wagen 4-achs",
+			"shortcut": "Bghw",
+			"speed": 120,
+			"weight": 30,
+			"force": 0,
+			"length": 19,
+			"drive": 0,
+			"reliability": 0.8,
+			"cost": 80000,
+			"exchangeTime": 120,
+			"capacity": [
+				{"name": "passengers", "value": 64}
+			]
+		},
+		{
 			"id": 8,
 			"group": 1,
 			"name": "Autotransportwagen",


### PR DESCRIPTION
- +Baagtr dreiachsiger Rekowagen für Traglasten
- +Bghw vierachsiger Rekowagen

Sofern überhaupt gewünscht würde ich noch Y-Wagen (oder B, B/Y) und Halberstädter machen (also Bmh oder als Regionalbahnwagen By 48). Andererseits sind die Halberstädter recht nach an den n-Wagen und stellen damit jetzt keine große Bereicherung dar.