### PR TITLE
TrainEquipment: Add BOStrab and ET2010 as first bostrab-compatible train

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -1317,6 +1317,27 @@
 				{"name": "passengers", "value": 570},
 				{"name": "bistroseats", "value": 20}
 			]
+		},
+		{
+			"id": 231,
+			"group": 2,
+			"name": "Bombardier Elektrotriebwagen 2010 (AVG/VBK)",
+			"shortcut": "ET2010",
+			"speed": 100,
+			"weight": 62,
+			"force": 37,
+			"length": 37,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 400000,
+			"operationCosts": 50,
+			"maxConnectedUnits": 4,
+			"equipments": [
+				"bostrab"
+			],
+			"capacity": [
+				{"name": "passengers", "value": 93}
+			]
 		}
 	]
 }

--- a/TrainEquipment.json
+++ b/TrainEquipment.json
@@ -27,6 +27,10 @@
 		{
 			"idString": "AT",
 			"name": "🇦🇹"
+		},
+		{
+			"idString": "bostrab",
+			"name": "BOStrab"
 		}
 	]
 }


### PR DESCRIPTION
This PR adds the "BO Strab"-Feature, indicating that a train can also run as a tram, together with the AVG (Albtal-Verkehrsgesellschaft) ET2010 as first bostrab-capable train.
This allows for further expansion with some "interesting" parts of the rail network e.g. in Karlsruhe, Kassel or Heilbronn with Tram-Train systems.