### PR TITLE
Add Rollenberg/Bruchsal Nord/Ubstadt connecting tracks

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -6920,8 +6920,13 @@
 				},
 				{
 					"start": "RSAB",
+					"end": "RROL",
+					"length": 15
+				},
+				{
+					"start": "RROL",
 					"end": "TV",
-					"length": 47
+					"length": 32
 				},
 				{
 					"start": "TV",
@@ -8625,10 +8630,52 @@
 				},
 				{
 					"start": "RBR",
+					"end": "RBRR",
+					"maxSpeed": 160,
+					"twistingFactor": 0.1,
+					"length": 2
+				},
+				{
+					"start": "RBRR",
+					"end": "RUWA",
+					"maxSpeed": 160,
+					"twistingFactor": 0.1,
+					"length": 2
+				},
+				{
+					"start": "RUWA",
 					"end": "RH",
 					"maxSpeed": 160,
 					"twistingFactor": 0.1,
-					"length": 32
+					"length": 28
+				}
+			]
+		},
+		{
+			"name": "Verbindungsstrecke Bruchsal",
+			"group": 2,
+			"electrified": true,
+			"objects": [
+				{
+					"start": "RBR",
+					"end": "RROL",
+					"maxSpeed": 100,
+					"twistingFactor": 0.5,
+					"length": 2
+				}
+			]
+		},
+		{
+			"name": "Verbindungsstrecke Ubstadt",
+			"group": 2,
+			"electrified": true,
+			"objects": [
+				{
+					"start": "RROL",
+					"end": "RROL",
+					"maxSpeed": 160,
+					"twistingFactor": 0.5,
+					"length": 3
 				}
 			]
 		},

--- a/Station.json
+++ b/Station.json
@@ -14274,6 +14274,30 @@
 			"y": 576,
 			"platformLength": 501,
 			"platforms": 14
+		},
+		{
+			"group": 4,
+			"name": "Bruchsal Nord",
+			"ril100": "RBRR",
+			"x": 287,
+			"y": 435,
+			"forRandomTasks": false
+		},
+		{
+			"group": 4,
+			"name": "Bruchsal Rollenberg",
+			"ril100": "RROL",
+			"x": 290,
+			"y": 434,
+			"forRandomTasks": false
+		},
+		{
+			"group": 4,
+			"name": "Ubstadt-Weiher Abzw.",
+			"ril100": "RUWA",
+			"x": 290,
+			"y": 431,
+			"forRandomTasks": false
 		}
 	]
 }


### PR DESCRIPTION
This PR tries to add the connecting tracks between the SFS and Heidelberg/Karlsruhe as good as possible with the limited space