### PR TITLE
Make more trains AT-capable

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -15,7 +15,7 @@
 			"cost": 2500000,
 			"maxConnectedUnits": 1,
 			"operationCosts": 100,
-			"equipments": ["ETCS", "CH"],
+			"equipments": ["ETCS", "CH", "AT"],
 			"exchangeTime": 120,
 			"capacity": [
 				{"name": "passengers", "value": 703},
@@ -56,7 +56,7 @@
 			"reliability": 1,
 			"cost": 2500000,
 			"operationCosts": 60,
-			"equipments": ["ETCS", "KRM", "CH"],
+			"equipments": ["ETCS", "KRM", "CH", "AT"],
 			"maxConnectedUnits": 2,
 			"exchangeTime": 120,
 			"capacity": [
@@ -77,7 +77,7 @@
 			"reliability": 1,
 			"cost": 4500000,
 			"operationCosts": 80,
-			"equipments": ["ETCS", "KRM", "CH"],
+			"equipments": ["ETCS", "KRM", "CH", "AT"],
 			"maxConnectedUnits": 1,
 			"exchangeTime": 120,
 			"capacity": [
@@ -163,7 +163,7 @@
 			"reliability": 1,
 			"cost": 2500000,
 			"operationCosts": 65,
-			"equipments": ["ETCS", "CH"],
+			"equipments": ["ETCS", "CH", "AT"],
 			"maxConnectedUnits": 2,
 			"exchangeTime": 120,
 			"capacity": [
@@ -588,7 +588,7 @@
 			"cost": 600000,
 			"operationCosts": 60,
 			"maxConnectedUnits": 2,
-			"equipments": ["CH"],
+			"equipments": ["CH", "AT"],
 			"capacity": [
 				{"name": "containers", "value": 15}
 			]

--- a/Train.json
+++ b/Train.json
@@ -766,7 +766,7 @@
 			"reliability": 1,
 			"cost": 450000,
 			"operationCosts": 110,
-			"equipments": ["ETCS", "CZ", "CH", "AT"]
+			"equipments": ["ETCS", "CZ", "CH", "AT", "NL"]
 		},
 		{
 			"id": 28,


### PR DESCRIPTION
Einige AT-geeignete Züge waren nicht korrekt gekennzeichnet.