### PR TITLE
Fügt NL-Equipment zu Flirt 1 (jetzt 2) und 3XL hinzu

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -294,7 +294,7 @@
 			"drive": 1,
 			"reliability": 1,
 			"cost": 480000,
-			"equipments": ["CH"],
+			"equipments": ["CH", "NL"],
 			"operationCosts": 42,
 			"maxConnectedUnits": 2,
 			"capacity": [
@@ -335,6 +335,7 @@
 			"operationCosts": 40,
 			"maxConnectedUnits": 3,
 			"compatibleWith": [1],
+			"equipments": ["NL"],
 			"capacity": [
 				{"name": "passengers", "value": 190}
 			]


### PR DESCRIPTION
Die Flirt 2 (lt. WIkipedia gibt es in DE nur Flirt 2 🤔) fahren derzeit für die €-Bahn nach Venlo, sollten also auch dafür tauglich sein.

START soll die Linie dann 2026 wohl mit Flirt 3XL übernehmen.

Perspektivisch könnte es Sinn ergeben, dass Züge auch Sub-Varianten haben, sodass dann nicht bspw. die Flirt 1/2 mehrsystemfähig von den Niederlanden bis in die Schweiz sind...