### PR TITLE
Fix Traverso operationCost & Bodio platform length

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -17185,7 +17185,7 @@
 			"group": 5,
 			"x": 329,
 			"y": 893,
-			"platformLength": 19,
+			"platformLength": 150,
 			"platforms": 1
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -414,6 +414,7 @@
 			"drive": 1,
 			"reliability": 1,
 			"cost": 600000,
+			"operationCosts": 60,
 			"maxConnectedUnits": 2,
 			"equipments": ["CH", "ETCS"],
 			"neededEquipments": ["CH"],


### PR DESCRIPTION
Ich habe wohl beim Traverso vergessen, Betriebskosten anzugeben 😵‍💫 und Bodio hat eine viel zu kurze Bahnsteiglänge...