### PR TITLE
ETCS Nachrüstung für Re 460 Lok 2000

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -1157,7 +1157,7 @@
 			"reliability": 1,
 			"cost": 380000,
 			"operationCosts": 90,
-			"equipments": ["CH"],
+			"equipments": ["CH", "ETCS"],
 			"neededEquipments": ["CH"]
 		},
 		{


### PR DESCRIPTION
ETCS Level 2 kam um die 2010er Jahre als Upgrade hinzu.

Aside: ~~Falls~~ Wenn Norwegen und Finnland hinzukommen, könnte man diese da auch freischalten, damit wir nicht zu viele Unterversionen einführen. Bei E-/Diesel-/Hybrid-Vectrons machte das Sinn. Die finnische Version darf real ,210 km/h - das ist ja nur ein marginaler Unterschiede.