### PR TITLE
Added Sudwesten Schwedens

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -16774,6 +16774,12 @@
 					"length": 12,
 					"maxSpeed": 160,
 					"twistingFactor": 0.5
+				},
+				{	"start": "XKDHL",
+					"end": "🇩🇰PB",
+					"length": 8,
+					"maxSpeed": 180,
+					"twistingFactor": 0.15
 				}
 			]
 		},
@@ -16797,6 +16803,41 @@
 					"length": 15,
 					"maxSpeed": 160,
 					"twistingFactor": 0.5
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"SE"
+			],
+			"objects": [
+				{
+					"start": "🇩🇰PB",
+					"end": "XVM",
+					"length": 24,
+					"maxSpeed": 200,
+					"twistingFactor": 0.37
+				},
+				{
+					"start": "XVM",
+					"end": "🇸🇪KL",
+					"length": 24,
+					"maxSpeed": 150,
+					"twistingFactor": 0.2
+				},
+				{	"start": "🇸🇪KL",
+					"end": "🇸🇪LK",
+					"length": 20,
+					"maxSpeed": 200,
+					"twistingFactor": 0.45
+				},
+				{	"start": "🇸🇪LK",
+					"end": "XVH",
+					"length": 22,
+					"maxSpeed": 200,
+					"twistingFactor": 0.25
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -21842,6 +21842,44 @@
 			"platformLength": 300,
 			"platforms": 2,
 			"laea": 1
+		},
+		{	"name": "Peberholm",
+			"ril100": "🇩🇰PB",
+			"group": 3,
+			"x": 851,
+			"y": -636
+		},
+		{	"name": "Malmö C",
+			"ril100": "XVM",
+			"group": 0,
+			"x": 885,
+			"y": -637,
+			"platformLength": 412,
+			"platforms": 10
+		},
+		{	"name": "Kävlinge",
+			"ril100": "🇸🇪KL",
+			"group": 2,
+			"x": 900,
+			"y": -668,
+			"platformLength": 255,
+			"platforms": 5
+		},
+		{	"name": "Landskrona",
+			"ril100": "🇸🇪LK",
+			"group": 2,
+			"x": 866,
+			"y": -682,
+			"platformLength": 350,
+			"platforms": 3
+		},
+		{ 	"name": "Helsingborg C",
+			"ril100": "XVH",
+			"group": 1,
+			"x": 844,
+			"y": -709,
+			"platformLength": 350,
+			"platforms": 4
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3021,6 +3021,87 @@
 			"neededCapacity": [
 				{ "name": "oil", "value": 720 }
 			]
+		},
+		{
+			"group": 1,
+			"name": "Containerzug von Krefeld nach Helsingborg ",
+			"service": 11,
+			"descriptions": [
+				"Verbinde das Rheinland mit dem Norden."
+			],
+			"stations": [ "KKR", "XVH" ],
+			"neededCapacity": [
+				{ "name": "containers", "value": 72 }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Güterzug von Hamburg nach Malmö ",
+			"service": 11,
+			"descriptions": [
+				"Bringe einen Kombinierten Güterzug nach Malmö."
+			],
+			"stations": [ "AHAR", "XVM" ],
+			"neededCapacity": [
+				{ "name": "containers", "value": 20 },
+				{ "name": "oil", "value": 660 },
+				{ "name": "wood", "value": 600 },
+				{ "name": "cars", "value": 60 }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Schwerer Intermodaltransport von von %s nach %s ",
+			"service": 11,
+			"descriptions": [
+				"Verbinde %s mit %s mit diesem Intermodalen Güterzug."
+			],
+			"stations": [ ],
+			"neededCapacity": [
+				{ "name": "containers", "value": 72 }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Güterzug von von %s nach %s ",
+			"service": 11,
+			"descriptions": [
+				"Verbinde %s mit %s mit diesem Güterzug."
+			],
+			"stations": [ ],
+			"neededCapacity": [
+				{ "name": "containers", "value": 20 },
+				{ "name": "oil", "value": 660 },
+				{ "name": "wood", "value": 600 },
+				{ "name": "cars", "value": 60 }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Öresundståg von XDKH nach XVH",
+			"service": 2,
+			"descriptions": [
+				"Verbinde Kopenhagen mit Helsingborg.",
+				"Fahre den Zug zwischen Dänemark und Schweden."
+			],
+			"stations": [ "XDKH", "XDKHL", "XVM", "🇸🇪KL", "🇸🇪LK", "XVH" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Öresundståg von XVH nach XDKH",
+			"service": 2,
+			"descriptions": [
+				"Verbinde Schweden mit Dänemark.",
+				"Fahre den Zug zwischen Helsingborg und Kopenhagen."
+			],
+			"stations": [ "XVH", "🇸🇪LK", "🇸🇪KL", "XVM", "XDKHL", "XDKH" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			]
 		}
+
 	]
 }

--- a/Train.json
+++ b/Train.json
@@ -785,6 +785,28 @@
 			]
 		},
 		{
+			"id": 322,
+			"group": 2,
+			"name": "DSB ER",
+			"shortcut": "IR4",
+			"speed": 180,
+			"weight": 133,
+			"force": 250,
+			"length": 77,
+			"drive": 1,
+			"reliability": 1,
+			"maxConnectedUnits": 5,
+			"equipments": [
+				"DK"
+			],
+			"neededEquipments": ["DK"],
+			"operationCosts": 85,
+			"cost": 500000,
+			"capacity": [
+				{"name": "passengers", "value": 227}
+			]
+		},
+		{
 			"id": 563,
 			"group": 2,
 			"name": "Siemens Mireo Plus H",
@@ -878,6 +900,28 @@
 			"equipments": ["ETCS", "DK"],
 			"capacity": [
 				{"name": "passengers", "value": 144}
+			]
+		},
+		{
+			"id": 355,
+			"group": 2,
+			"name": "DSB MG",
+			"shortcut": "IC4",
+			"speed": 200,
+			"weight": 160,
+			"force": 150,
+			"length": 86,
+			"drive": 2,
+			"reliability": 0.8,
+			"maxConnectedUnits": 4,
+			"equipments": [
+				"DK"
+			],
+			"neededEquipments": ["DK"],
+			"operationCosts": 100,
+			"cost": 500000,
+			"capacity": [
+				{"name": "passengers", "value": 208}
 			]
 		},
 		{
@@ -1370,7 +1414,7 @@
 			"reliability": 1,
 			"cost": 450000,
 			"operationCosts": 110,
-			"equipments": ["ETCS", "CZ", "CH", "AT", "NL", "BE", "IT", "PL"]
+			"equipments": ["ETCS", "CZ", "CH", "AT", "NL", "BE", "IT", "PL", "DK", "SE"]
 		},
 		{
 			"id": 248,
@@ -1485,7 +1529,7 @@
 			"reliability": 0.9,
 			"cost": 400000,
 			"operationCosts": 120,
-			"equipments": ["GB", "NL", "BE", "LU", "DK", "PL", "CZ", "FR"]
+			"equipments": ["GB", "NL", "BE", "LU", "DK", "PL", "CZ", "FR", "SE"]
 		},
 		{
 			"id": 17,


### PR DESCRIPTION
Route geht jetzt von Kopenhagen Flughafen über Malmö, Kävlinge, Landskrona nach Helsingborg. Zusätzlich habe ich 2 Dänische Triebzüge hinzugefügt, die Länderzulassungen der Class 66 und der Vectron MS um DK und SE ergänzt, und ein paar Aufgaben hinzugefügt. 