### PR TITLE
Update Taskmodel.json // Sprogø von den dänischen Regionalleistungen entfernt

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3457,7 +3457,7 @@
 				"Verbinde die Menschen im Norden von %s bis %s.",
 				"Bediene die Regionalleistung zwischen %s und %s."
 			],
-			"stations": [ "XDTI", "XDRD", "XDV", "XDLU", "XDKO", "XDTA", "XDMF", "🇩🇰KL", "🇩🇰NA", "XDEY", "🇩🇰GS", "🇩🇰AR", "🇩🇰BD", "🇩🇰SB", "🇩🇰TM", "🇩🇰HS", "XDOD", "XDNY", "🇩🇰SG", "XDKS", "XDSGE", "XDSOR", "XDRI", "XDBOP", "XDVI", "XDRK", "XDHT", "XDKH" ],
+			"stations": [ "XDTI", "XDRD", "XDV", "XDLU", "XDKO", "XDTA", "XDMF", "🇩🇰KL", "🇩🇰NA", "XDEY", "🇩🇰GS", "🇩🇰AR", "🇩🇰BD", "🇩🇰SB", "🇩🇰TM", "🇩🇰HS", "XDOD", "XDNY", "XDKS", "XDSGE", "XDSOR", "XDRI", "XDBOP", "XDVI", "XDRK", "XDHT", "XDKH" ],
 			"neededCapacity": [
 				{ "name": "passengers", "value": 0 }
 			]


### PR DESCRIPTION
Sprogø war fälschlicherweise als Halt eingetragen und hat dadurch für Fehler gesorgt, siehe Twitter
https://twitter.com/f2k1de/status/1548955011585114113