### PR TITLE
Add Avelia Horizon

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -185,7 +185,7 @@
 			"reliability": 0.9,
 			"cost": 6500000,
 			"operationCosts": 70,
-			"equipments": [ "ETCS", "FR", "TVM", "BE", "LU" ],
+			"equipments": [ "ETCS", "FR", "TVM", "BE", "IT", "LU" ],
 			"maxConnectedUnits": 2,
 			"exchangeTime": 150,
 			"capacity": [

--- a/Train.json
+++ b/Train.json
@@ -173,6 +173,27 @@
 			]
 		},
 		{
+			"id": 872024,
+			"group": 2,
+			"name": "Alstom Avelia Horizon",
+			"shortcut": "TGV M",
+			"speed": 350,
+			"weight": 360,
+			"force": 300,
+			"length": 200,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 6500000,
+			"operationCosts": 70,
+			"equipments": [ "ETCS", "FR", "TVM", "BE", "LU" ],
+			"maxConnectedUnits": 2,
+			"exchangeTime": 150,
+			"capacity": [
+				{ "name": "passengers", "value": 611 },
+				{ "name": "bistroseats", "value": 12 }
+			]
+		},
+		{
 			"id": 4403,
 			"group": 2,
 			"name": "TGV POS",


### PR DESCRIPTION
Daten zu großen Teilen ausgedacht, Zulassungen ebenfalls (basierend darauf, was lt. Wikipedia FR an Stromsystemen möglich ist und irgendwie Sinn ergeben könnte)