### PR TITLE
add Eurotunnel Class 0001

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -1891,7 +1891,21 @@
 			"reliability": 1,
 			"cost": 450000,
 			"operationCosts": 200
-
+		},
+		{
+			"id": 6400,
+			"group": 0,
+			"name": "Eurotunnel Class 0001",
+			"shortcut": "Class 21",
+			"speed": 100,
+			"weight": 90,
+			"force": 290,
+			"length": 14,
+			"drive": 2,
+			"reliability": 1,
+			"cost": 250000,
+			"operationCosts": 115,
+			"equipments": ["GB", "FR", "BE", "NL", "Eurotunnel", "TVM"]
 		},
 		{
 			"id": 245,

--- a/Train.json
+++ b/Train.json
@@ -1903,7 +1903,7 @@
 			"length": 14,
 			"drive": 2,
 			"reliability": 1,
-			"cost": 250000,
+			"cost": 350000,
 			"operationCosts": 115,
 			"equipments": ["GB", "FR", "BE", "NL", "Eurotunnel", "TVM"]
 		},


### PR DESCRIPTION
Daß die Kiste TVM kann ist nur ein Hack. Man _könnte_ auch dem Eurotunnel das TVM wegnehmen. Die realitätsnähere Lösung wäre aber vermutlich, TVM/ECTS/(LZB) als Enabler für höhere Geschwindigkeiten einzubauen 😞