### PR TITLE
Git checkout tools with submodules

### DIFF
--- a/.github/workflows/check_content.yml
+++ b/.github/workflows/check_content.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           repository: 'C1710/TrainCompany-tools'
           path: 'tools'
+          submodules: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/create_map.yml
+++ b/.github/workflows/create_map.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           repository: 'C1710/TrainCompany-tools'
           path: 'tools'
+          submodules: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/project_coordinates.yml
+++ b/.github/workflows/project_coordinates.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           repository: 'C1710/TrainCompany-tools'
           path: 'tools'
+          submodules: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'


### PR DESCRIPTION
Ich habe in meinen Tools jetzt noch die [Trainline-Stations-Datensätze](https://github.com/trainline-eu/stations) drin, die als Submodul eingebunden werden.  
Das muss aber mit geladen werden...

Ich muss das aber erst noch alles ausprobieren usw.