### PR TITLE
Issue Template für Erweiterungen

### DIFF
--- a/.github/ISSUE_TEMPLATE/erweiterung.md
+++ b/.github/ISSUE_TEMPLATE/erweiterung.md
@@ -1,0 +1,19 @@
+---
+name: Erweiterung
+about: Erweiterung um eine Strecke/Zug/Task
+title: ''
+labels: extension
+assignees: ''
+
+---
+
+## Was wird hinzugefügt?
+
+## Art der Erweiterung
+- [ ] Strecke
+- [ ] Zug
+- [ ] Aufgabe
+- [ ] Ladungsart
+- [ ] Verspätung
+
+## Weitere Details


### PR DESCRIPTION
Mit der Vorlage ließen sich dann Streckenerweiterungen vielleicht einfacher als Issue erstellen und hätten auch automatisch das richtige Label.

Ich weiß aber nicht, ob/wie gut das funktioniert und ob dann auch alle weiterhin "normale" Issues erstellen können.