### PR TITLE
Erhöhung der Zuverlässigkeit des Avelia Horizon to 100%

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -182,7 +182,7 @@
 			"force": 300,
 			"length": 200,
 			"drive": 1,
-			"reliability": 0.9,
+			"reliability": 1.0,
 			"cost": 6500000,
 			"operationCosts": 70,
 			"equipments": [ "ETCS", "FR", "TVM", "BE", "IT", "LU" ],


### PR DESCRIPTION
Ich hatte die ursprünglich auf 90% festgelegt, weil der Zug ja noch nicht ausgeliefert ist.
Aber beim ECx z.B. ist die auch 100% und es ergibt eigentlich wenig Sinn, wieso das hier nicht auch der Fall sein sollte (Alstom hat ja auch durchaus Erfahrung in Bau und Entwicklung von TGVs).

Außerdem passt der Preis halt auch eigentlich nicht bei der geringeren Zuverlässigkeit...