### PR TITLE
Verfeinerung Nordhausen-Erfurter Bahn

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -5498,19 +5498,117 @@
 			"electrified": false,
 			"objects": [
 				{
-					"start": "UN",
-					"end": "USF",
-					"twistingFactor": 0.5,
-					"length": 54,
-					"maxSpeed": 90
-				},
-				{
-					"start": "USF",
-					"end": "UE P",
-					"twistingFactor": 0.35,
-					"length": 27,
-					"maxSpeed": 100
-				}
+        			"start": "UE  P",
+        			"end": "UEN",
+        			"length": 5,
+					"maxSpeed": 90,
+					"twistingFactor": 0.3
+    			},
+    			{
+        			"start": "UEN",
+        			"end": "UEGI",
+        			"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.0
+    			},
+    			{
+        			"start": "UEGI",
+        			"end": "UKU",
+        			"length": 2,
+					"maxSpeed": 100,
+					"twistingFactor": 0.0
+    			},
+    			{
+        			"start": "UKU",
+        			"end": "UWL",
+        			"length": 4,
+					"maxSpeed": 100,
+					"twistingFactor": 0.05
+    			},
+    			{
+        			"start": "UWL",
+        			"end": "URGS",
+        			"length": 4,
+					"maxSpeed": 100,
+					"twistingFactor": 0.05
+    			},
+    			{
+        			"start": "URGS",
+        			"end": "USF",
+        			"length": 8,
+					"maxSpeed": 100,
+					"twistingFactor": 0.2
+    			},
+    			{
+        			"start": "USF",
+        			"end": "UGSM",
+        			"length": 4,
+					"maxSpeed": 90,
+					"twistingFactor": 0.2
+    			},
+    			{
+        			"start": "UGSM",
+        			"end": "UGN",
+        			"length": 5,
+					"maxSpeed": 90,
+					"twistingFactor": 0.3
+    			},
+    			{
+        			"start": "UGN",
+        			"end": "UWTL",
+        			"length": 5,
+					"maxSpeed": 90,
+					"twistingFactor": 0.2
+    			},
+    			{
+        			"start": "UWTL",
+        			"end": "UNI",
+        			"length": 6,
+					"maxSpeed": 90,
+					"twistingFactor": 0.5
+    			},
+    			{
+        			"start": "UNI",
+        			"end": "UHOO",
+        			"length": 3,
+					"maxSpeed": 90,
+					"twistingFactor": 0.1
+    			},
+    			{
+        			"start": "UHOO",
+        			"end": "USH",
+        			"length": 10,
+					"maxSpeed": 90,
+					"twistingFactor": 0.5
+    			},
+    			{
+        			"start": "USH",
+        			"end": "UGL",
+        			"length": 2,
+					"maxSpeed": 110,
+					"twistingFactor": 0.3
+    			},
+    			{
+        			"start": "UGL",
+        			"end": "UGFA",
+        			"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.1
+    			},
+    			{
+        			"start": "UGFA",
+        			"end": "UKFA",
+        			"length": 3,
+					"maxSpeed": 110,
+					"twistingFactor": 0.2
+    			},
+    			{
+        			"start": "UKFA",
+        			"end": "UN",
+        			"length": 12,
+					"maxSpeed": 140,
+					"twistingFactor": 0.2
+    			}
 			]
 		},
 		{

--- a/Path.json
+++ b/Path.json
@@ -5498,7 +5498,7 @@
 			"electrified": false,
 			"objects": [
 				{
-        			"start": "UE  P",
+        			"start": "UE P",
         			"end": "UEN",
         			"length": 5,
 					"maxSpeed": 90,

--- a/Station.json
+++ b/Station.json
@@ -7316,6 +7316,132 @@
 			"proj": 1
 		},
 		{
+        	"group": 5,
+        	"name": "Erfurt Nord",
+        	"ril100": "UEN",
+        	"x": 617,
+        	"y": 126,
+        	"platformLength": 153,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Erfurt-Gispersleben",
+        	"ril100": "UEGI",
+        	"x": 613,
+        	"y": 123,
+        	"platformLength": 94,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 2,
+        	"name": "Kühnhausen",
+        	"ril100": "UKU",
+        	"x": 610,
+        	"y": 121,
+        	"platformLength": 151,
+        	"platforms": 3
+    	},
+    	{
+        	"group": 5,
+        	"name": "Walschleben",
+        	"ril100": "UWL",
+        	"x": 607,
+        	"y": 115,
+        	"platformLength": 116,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Ringleben-Gebesee",
+        	"ril100": "URGS",
+        	"x": 608,
+        	"y": 109,
+        	"platformLength": 90,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Gangloffsömmern",
+        	"ril100": "UGSM",
+        	"x": 607,
+        	"y": 95,
+        	"platformLength": 100,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Greußen",
+        	"ril100": "UGN",
+        	"x": 605,
+        	"y": 89,
+        	"platformLength": 112,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Wasserthaleben",
+        	"ril100": "UWTL",
+        	"x": 598,
+        	"y": 84,
+        	"platformLength": 105,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Niederspier",
+        	"ril100": "UNI",
+        	"x": 593,
+        	"y": 79,
+        	"platformLength": 112,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Hohenebra Ort",
+        	"ril100": "UHOO",
+        	"x": 587,
+        	"y": 76,
+        	"platformLength": 90,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 2,
+        	"name": "Sondershausen",
+        	"ril100": "USH",
+        	"x": 593,
+        	"y": 65,
+        	"platformLength": 100,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Sondershausen Glückauf",
+        	"ril100": "UGL",
+        	"x": 590,
+        	"y": 62,
+        	"platformLength": 86,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Großfurra",
+        	"ril100": "UGFA",
+        	"x": 586,
+        	"y": 60,
+        	"platformLength": 93,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Kleinfurra",
+        	"ril100": "UKFA",
+        	"x": 581,
+        	"y": 57,
+        	"platformLength": 95,
+        	"platforms": 2
+    	},
+		{
 			"group": 2,
 			"name": "Enkenbach",
 			"ril100": "SENK",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3142,16 +3142,42 @@
 			"group": 1
 		},
 		{
-			"name": "Nordthüringenbahn von %s nach %s",
+			"name": "RE 55 von %s nach %s",
 			"service": 3,
 			"descriptions": [
-				"Bringe den Regionalexpress der Linie 55 von %s nach %s.",
-				"Bring die Fahrgäste in dem RE 55 pünktlich nach %2$s.",
-				"Bringe den Regionalexpress der Linie 56 von %s nach %s.",
-				"Bring die Fahrgäste in dem RE 56 pünktlich nach %2$s.",
+				"Bringe den Regionalexpress der Nordthüringenbahn von %s nach %s.",
+				"Bring die Fahrgäste im RE 55 pünktlich nach %2$s.",
 				"Fahre den RE störungsfrei nach %2$s."
 			],
-			"stations": [ "UN", "USF", "UE P" ],
+			"stations": [ "UN", "USH", "UGN", "USF", "URGS", "UWL", "UKU", "UEGI", "UEN", "UE P" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1
+		},
+		{
+			"name": "RE 56 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe den Regionalexpress der Nordthüringenbahn von %s nach %s.",
+				"Bring die Fahrgäste im RE 56 pünktlich nach %2$s.",
+				"Fahre den RE störungsfrei nach %2$s."
+			],
+			"stations": [ "UN", "UKFA", "UGFA", "UGL", "USH", "UHOO", "UNI", "UWTL", "UGN", "UGSM", "USF", "URGS", "UEN", "UE P" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1
+		},
+		{
+			"name": "RB 56 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe die Regionalbahn der Nordthüringenbahn von %s nach %s.",
+				"Bring die Fahrgäste in der RB 56 pünktlich nach %2$s.",
+				"Fahre die RB störungsfrei nach %2$s."
+			],
+			"stations": [ "UN", "UKFA", "UGFA", "UGL", "USH", "UHOO", "UNI", "UWTL", "UGN", "UGSM", "USF", "URGS", "UWL", "UKU", "UEGI", "UEN", "UE P" ],
 			"neededCapacity": [
 				{ "name": "passengers", "value": 0 }
 			],


### PR DESCRIPTION
Fügt alle Bahnhöfe/Haltepunkte des Personenverkehrs außer Werther und Wolkramshausen hinzu.
(Letztere würden die Routenauswahl erschweren, da sich der Abzweig von der Halle-Kasseler Bahn nach Wolkramshausen verschieben würde.)
Teilt dementsprechend auch die bisherige Ausschreibung für RE 55 oder RE 56 in zwei Ausschreibungen mit den passenden Haltemustern auf und fügt die in Tagesrandlagen stattdessen verkehrende RB 56 hinzu.

Ziel: Realistischere Fahrzeuganforderungen bei den Ausschreibungen, was Länge und Beschleunigung angeht.