### PR TITLE
fix/harmonize allowed RilCode length in TaskModel pathSuggestions

### DIFF
--- a/schemas/TaskModel.json
+++ b/schemas/TaskModel.json
@@ -118,7 +118,7 @@
 					"items": {
 						"type": "string",
 						"minLength": 2,
-						"maxLength": 10
+						"maxLength": 20
 					}
 				},
 				"stopsEverwhere": {


### PR DESCRIPTION
gefunden in https://github.com/marhei/TrainCompany-Data/pull/418#issuecomment-1199267096

```
				"stations": {
					"description": "Ril100 aller Bahnhöfe, die angefahren werden sollen in der richtigen Reihenfolge.\nWird keiner angegeben, werden zwei zufällige gewählt.",
					"type": "array",
					"items": {
						"type": "string",
						"minLength": 2,
						"maxLength": 20
					}
				},
				"pathSuggestion": {
					"description": "Ril100 aller Bahnhöfe, die standardmäßig mit oder ohne Halt angefahren werden sollen in der richtigen Reihenfolge.",
					"type": "array",
					"items": {
						"type": "string",
						"minLength": 2,
						"maxLength": 10
					}
				},
```

Das riecht eigentlich auch ein bischen nach Extract-Refactoring. Gehen File-übergreifende Typen bei json-Schemas überhaupt?