### PR TITLE
Add Nordhausen - Northeim - Bodenfelde

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -5967,10 +5967,26 @@
 			"twistingFactor": 0.3,
 			"objects": [
 				{
-					"start": "HG",
-					"end": "HK",
-					"length": 39
-				},
+        			"start": "HG",
+        			"end": "HNTH",
+        			"length": 9
+    			},
+    			{
+        			"start": "HNTH",
+        			"end": "HN",
+        			"length": 10
+    			},
+    			{
+        			"start": "HN",
+        			"end": "HEB",
+        			"length": 12
+    			},
+    			{
+        			"start": "HEB",
+        			"end": "HK",
+        			"length": 8,
+					"maxSpeed": 110
+    			},
 				{
 					"start": "HK",
 					"end": "HELZ",

--- a/Path.json
+++ b/Path.json
@@ -5974,7 +5974,7 @@
         			"end": "HN",
         			"length": 16,
 					"name": "Sollingbahn"
-    			}
+    			},
 				{
 					"start": "HBOF",
 					"end": "HG",

--- a/Path.json
+++ b/Path.json
@@ -5984,6 +5984,76 @@
 			]
 		},
 		{
+			"group": 1,
+			"electrified": false,
+			"maxSpeed": 100,
+			"name": "Südharzstrecke",
+			"twistingFactor": 0.3,
+			"objects": [
+				{
+        			"start": "HN",
+        			"end": "HKAT",
+        			"length": 8
+    			},
+    			{
+        			"start": "HKAT",
+        			"end": "HWUL",
+					"maxSpeed": 90,
+        			"length": 7
+    			},
+    			{
+        			"start": "HWUL",
+        			"end": "HHTF",
+        			"length": 4
+    			},
+    			{
+        			"start": "HHTF",
+        			"end": "HHB",
+        			"length": 8
+    			},
+    			{
+        			"start": "HHB",
+        			"end": "HBLB",
+        			"length": 7
+    			},
+    			{
+        			"start": "HBLB",
+        			"end": "HSCH",
+        			"length": 13
+    			},
+    			{
+        			"start": "HSCH",
+        			"end": "HWKD",
+        			"length": 2
+    			},
+    			{
+        			"start": "HWKD",
+        			"end": "UER",
+        			"length": 5
+    			},
+    			{
+        			"start": "UER",
+        			"end": "UWOF",
+        			"length": 5
+    			},
+    			{
+        			"start": "UWOF",
+        			"end": "UNIW",
+        			"length": 3
+    			},
+    			{
+        			"start": "UNIW",
+        			"end": "UNSA",
+        			"length": 4
+    			},
+    			{
+        			"start": "UNSA",
+        			"end": "UN",
+        			"length": 2
+    			}
+			]
+		},
+		{
 			"group": 0,
 			"electrified": true,
 			"maxSpeed": 160,

--- a/Path.json
+++ b/Path.json
@@ -5952,6 +5952,30 @@
 					"name": "Sollingbahn"
 				},
 				{
+        			"start": "HBOF",
+        			"end": "HUS",
+        			"length": 8,
+					"name": "Sollingbahn"
+    			},
+    			{
+        			"start": "HUS",
+        			"end": "HVOP",
+        			"length": 7,
+					"name": "Sollingbahn"
+    			},
+    			{
+        			"start": "HVOP",
+        			"end": "HHRD",
+        			"length": 6,
+					"name": "Sollingbahn"
+    			},
+    			{
+        			"start": "HHRD",
+        			"end": "HN",
+        			"length": 16,
+					"name": "Sollingbahn"
+    			}
+				{
 					"start": "HBOF",
 					"end": "HG",
 					"length": 37,

--- a/Station.json
+++ b/Station.json
@@ -9399,6 +9399,33 @@
 			"proj": 1
 		},
 		{
+        	"group": 5,
+        	"name": "Uslar",
+        	"ril100": "HUS",
+        	"x": 431,
+        	"y": 18,
+        	"platformLength": 170,
+        	"platforms": 2
+    	},
+		{
+        	"group": 5,
+        	"name": "Volpriehausen",
+        	"ril100": "HVOP",
+        	"x": 442,
+        	"y": 17,
+        	"platformLength": 140,
+        	"platforms": 1
+    	},
+		{
+        	"group": 5,
+        	"name": "Hardegsen",
+        	"ril100": "HHRD",
+        	"x": 454,
+        	"y": 17,
+        	"platformLength": 175,
+        	"platforms": 2
+    	},
+		{
 			"group": 2,
 			"name": "Elze (Han)",
 			"ril100": "HELZ",

--- a/Station.json
+++ b/Station.json
@@ -9379,6 +9379,105 @@
         	"platforms": 4
     	}
 		{
+        	"group": 5,
+        	"name": "Katlenburg",
+        	"ril100": "HKAT",
+        	"x": 491,
+        	"y": 13,
+        	"platformLength": 140,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Wulften",
+        	"ril100": "HWUL",
+        	"x": 501,
+        	"y": 17,
+        	"platformLength": 110,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Hattorf",
+        	"ril100": "HHTF",
+        	"x": 510,
+        	"y": 19,
+        	"platformLength": 140,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 2,
+        	"name": "Herzberg (Harz)",
+        	"ril100": "HHB",
+        	"x": 522,
+        	"y": 20,
+        	"platformLength": 140,
+        	"platforms": 3
+    	},
+    	{
+        	"group": 5,
+        	"name": "Bad Lauterberg-Barbis",
+        	"ril100": "HBLB",
+        	"x": 534,
+        	"y": 24,
+        	"platformLength": 90,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Bad Sachsa",
+        	"ril100": "HSCH",
+        	"x": 555,
+        	"y": 30,
+        	"platformLength": 160,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Walkenried",
+        	"ril100": "HWKD",
+        	"x": 560,
+        	"y": 30,
+        	"platformLength": 220,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Ellrich",
+        	"ril100": "UER",
+        	"x": 568,
+        	"y": 30,
+        	"platformLength": 181,
+        	"platforms": 2
+    	},
+    	{
+        	"group": 5,
+        	"name": "Woffleben",
+        	"ril100": "UWOF",
+        	"x": 575,
+        	"y": 34,
+        	"platformLength": 90,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Niedersachswerfen",
+        	"ril100": "UNIW",
+        	"x": 581,
+        	"y": 36,
+        	"platformLength": 94,
+        	"platforms": 1
+    	},
+    	{
+        	"group": 5,
+        	"name": "Nordhausen-Salza",
+        	"ril100": "UNSA",
+        	"x": 582,
+        	"y": 41,
+        	"platformLength": 93,
+        	"platforms": 1
+    	},
+		{
 			"group": 2,
 			"name": "Höxter-Ottbergen",
 			"ril100": "HOTT",

--- a/Station.json
+++ b/Station.json
@@ -9377,7 +9377,7 @@
         	"y": -6,
         	"platformLength": 220,
         	"platforms": 4
-    	}
+    	},
 		{
         	"group": 5,
         	"name": "Katlenburg",

--- a/Station.json
+++ b/Station.json
@@ -9352,6 +9352,33 @@
 			"proj": 1
 		},
 		{
+        	"group": 5,
+        	"name": "Nörten-Hardenberg",
+        	"ril100": "HNTH",
+        	"x": 468,
+        	"y": 22,
+        	"platformLength": 302,
+        	"platforms": 2
+    	},
+		{
+        	"group": 2,
+        	"name": "Northeim (Han)",
+        	"ril100": "HN",
+        	"x": 476,
+        	"y": 10,
+        	"platformLength": 245,
+        	"platforms": 6
+    	},
+		{
+        	"group": 2,
+        	"name": "Einbeck-Salzderhelden",
+        	"ril100": "HEB",
+        	"x": 467,
+        	"y": -6,
+        	"platformLength": 220,
+        	"platforms": 4
+    	}
+		{
 			"group": 2,
 			"name": "Höxter-Ottbergen",
 			"ril100": "HOTT",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -970,7 +970,7 @@
 			"objects": [
 				{
 					"stations": [ "HH", "HELZ", "HK", "HG", "FKW", "FFU", "NWH" ],
-					"pathSuggestion": [ "HH", "HELZ", "HK", "HG", "FKW", "FFU", "NBN", "NRB", "NWH" ]
+					"pathSuggestion": [ "HH", "HELZ", "HK", "HN", "HG", "FKW", "FFU", "NBN", "NRB", "NWH" ]
 				},
 				{
 					"stations": [ "HH", "EHFD", "EBILP", "EGLO", "EHM", "EDO", "EBO", "EE", "EDG", "KD", "KK" ],
@@ -1040,7 +1040,7 @@
 				},
 				{
 					"stations": [ "BL", "BPD", "LM", "HHI", "HG", "HEBG", "FB", "FFU", "FH", "RM", "RK", "RF", "RB", "XSB", "XSZH" ],
-					"pathSuggestion": [ "BL", "BPD", "LM", "HBS", "HHI", "HELZ", "HK", "HG", "HEBG", "FB", "FFU", "FFD", "FH", "FF", "FFLF", "FBL", "RM", "RSAB", "RGN", "RK", "RAP", "RO", "RF", "RML", "RB", "XSB", "XSKS", "XSZH" ]
+					"pathSuggestion": [ "BL", "BPD", "LM", "HBS", "HHI", "HELZ", "HK", "HN", "HG", "HEBG", "FB", "FFU", "FFD", "FH", "FF", "FFLF", "FBL", "RM", "RSAB", "RGN", "RK", "RAP", "RO", "RF", "RML", "RB", "XSB", "XSKS", "XSZH" ]
 				},
 				{
 					"stations": [ "XAWW", "XAP", "XAL", "XAWE", "NPA", "NRH", "NN", "FFLF", "FMZ", "KKO", "KB", "KK", "KD", "EEM", "XNAC" ],
@@ -2484,7 +2484,7 @@
 				"Bring die Fahrgäste mit oder ohne Fahrräder pünktlich durch das Leinetal und an die Aller.",
 				"Bring den RE2 von %s nach %s. Die Strecke ist stark ausgelastet."
 			],
-			"stations": [ "HG", "HK", "HELZ", "HH", "HC", "HU" ],
+			"stations": [ "HG", "HNTH", "HN", "HEB", "HK", "HELZ", "HH", "HC", "HU" ],
 			"neededCapacity": [
 				{ "name": "passengers", "value": 0 }
 			]
@@ -4039,7 +4039,7 @@
 				{
 					"descriptions": [ "Fahre den TEE Helvetia von %s bis %s" ],
 					"stations": [ "AA", "AH", "HH", "HG", "FF", "RM", "RK", "RO", "RF", "RB", "XSB", "XSZH" ],
-					"pathSuggestion": [ "AA", "AH", "ABLZ", "HH", "HELZ", "HK", "HG", "HEBG", "FB", "FFU", "FFD", "FH", "FF", "FFLF", "FBL", "RM", "RMF", "RH", "RBR", "RK", "RAP", "RO", "RF", "RML", "RB", "XSB", "XSKS", "XSZH" ]
+					"pathSuggestion": [ "AA", "AH", "ABLZ", "HH", "HELZ", "HK", "HN", "HG", "HEBG", "FB", "FFU", "FFD", "FH", "FF", "FFLF", "FBL", "RM", "RMF", "RH", "RBR", "RK", "RAP", "RO", "RF", "RML", "RB", "XSB", "XSKS", "XSZH" ]
 				},
 				{
 					"descriptions": [ "Fahre den TEE Albert Schweitzer von %s bis %s" ],
@@ -4068,7 +4068,7 @@
 				{
 					"descriptions": [ "Fahre den TEE Prinz Eugen von %s bis %s" ],
 					"stations": [ "HB", "HH", "HG", "FB", "NWH", "NN", "NRH", "NPA", "XAWE", "XAL", "XAWW" ],
-					"pathSuggestion": [ "HB", "HV", "HWUN", "HH", "HELZ", "HK", "HG", "HEBG", "FB", "FFU", "NBN", "NGM", "NWH", "NRTD", "NF", "NN", "NRH", "NOT", "NPL", "NPA", "XASH", "🇦🇹Neu H1", "XAWE", "XAL", "XAWW" ]
+					"pathSuggestion": [ "HB", "HV", "HWUN", "HH", "HELZ", "HK", "HN", "HG", "HEBG", "FB", "FFU", "NBN", "NGM", "NWH", "NRTD", "NF", "NN", "NRH", "NOT", "NPL", "NPA", "XASH", "🇦🇹Neu H1", "XAWE", "XAL", "XAWW" ]
 				}
 			],
 			"neededCapacity": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3385,6 +3385,51 @@
 			"stopsEverywhere": true
 		},
 		{
+			"name": "RB 80 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe die Regionalbahn über die Südharzstrecke von %s nach %s.",
+				"Bring die Fahrgäste auf der Südharzstrecke pünktlich nach %2$s.",
+				"Fahre die RB störungsfrei nach %2$s."
+			],
+			"stations": [ "UN", "HHB", "HN", "HG" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1,
+			"stopsEverywhere": true
+		},
+		{
+			"name": "RB 81 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe die Regionalbahn über die Südharzstrecke von %s nach %s.",
+				"Bring die Fahrgäste auf der Südharzstrecke pünktlich nach %2$s.",
+				"Fahre die RB störungsfrei nach %2$s."
+			],
+			"stations": [ "UN", "HHB", "HN", "HBOF" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1,
+			"stopsEverywhere": true
+		},
+		{
+			"name": "RB 82 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe die Regionalbahn der Linie 82 von %s nach %s.",
+				"Bring die Fahrgäste der RB 82 pünktlich nach %2$s.",
+				"Fahre die RB störungsfrei nach %2$s."
+			],
+			"stations": [ "HBHA", "HVBG", "HGS", "HSSN", "HK", "HN", "HG" ],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1,
+			"stopsEverywhere": true
+		},
+		{
 			"name": "Eurotunnel Le Shuttle nach %2$s",
 			"service": 10,
 			"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2965,7 +2965,7 @@
 				"Bring die Fahrgäste in der RB 85 pünktlich nach %2$s.",
 				"Fahre die RB störungsfrei nach %2$s."
 			],
-			"stations": [ "EPD", "HA", "HOTT", "HG" ],
+			"stations": [ "EPD", "HA", "HOTT", "HBOF", "HG" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers", "value": 0 }


### PR DESCRIPTION
Fügt die Strecke Nordhausen - Northeim (Han) "Südharzstrecke" hinzu.
Fügt die Strecke Northeim (Han) - Bodenfelde "Sollingbahn" hinzu.
Fügt die Bahnhöfe Nörten-Hardenberg, Northeim (Han) und Einbeck-Salzderhelden auf der Strecke Göttingen - Kreiensen "Hannöversche Südbahn" hinzu.
Passt einige Aufträge an die neuen Bahnhöfe und die neue Knotenpunktfunktion von Bodenfelde an.
Fügt Ausschreibungen für die niedersächsischen Regionalbahnen 80, 81 und 82 hinzu. (Nordhausen - Göttingen, Nordhausen - Bodenfelde, Bad Harzburg - Göttingen)