### PR TITLE
Add Saarbahn (Tram-Train)

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -874,6 +874,82 @@
 			]
 		},
 		{
+			"name": "Saarbahn",
+			"group": 1,
+			"electrified": true,
+			"objects": [
+				{
+        			"start": "XFSM",
+        			"end": "SHN",
+					"twistingFactor": 0.2,
+        			"length": 2,
+					"maxSpeed": 60
+    			},
+    			{
+        			"start": "SHN",
+        			"end": "SAM",
+					"twistingFactor": 0.15,
+        			"length": 2,
+					"maxSpeed": 100
+    			},
+    			{
+        			"start": "SAM",
+        			"end": "SKB",
+					"twistingFactor": 0.15,
+        			"length": 2,
+					"maxSpeed": 100
+    			},
+    			{
+        			"start": "SKB",
+        			"end": "SBN",
+					"twistingFactor": 0.25,
+        			"length": 3,
+					"maxSpeed": 100
+    			},
+    			{
+        			"start": "SBN",
+        			"end": "SGD",
+					"twistingFactor": 0.2,
+        			"length": 2,
+					"maxSpeed": 100
+    			},
+    			{
+        			"start": "SGD",
+        			"end": "SBA",
+					"twistingFactor": 0.05,
+        			"length": 2,
+					"maxSpeed": 100
+    			},
+				{
+        			"start": "SBA",
+        			"end": "SSH",
+					"twistingFactor": 0.15,
+        			"length": 4,
+					"maxSpeed": 30,
+					"neededEquipments": [
+						"bostrab"
+					]
+    			},
+				{
+        			"start": "SSH",
+        			"end": "SLCH",
+					"twistingFactor": 0.3,
+        			"length": 25,
+					"maxSpeed": 45,
+					"neededEquipments": [
+						"bostrab"
+					]
+    			},
+				{
+        			"start": "SLCH",
+        			"end": "SLCJ",
+					"twistingFactor": 0.05,
+        			"length": 1,
+					"maxSpeed": 40
+    			}
+			]
+		},
+		{
 			"name": "Pfälzische Ludwigsbahn",
 			"twistingFactor": 0.2,
 			"maxSpeed": 160,

--- a/Station.json
+++ b/Station.json
@@ -2352,7 +2352,7 @@
 			"forRandomTasks": false
     	},
     	{
-        	"group": "2",
+        	"group": 2,
         	"name": "Sarreguemines",
         	"ril100": "XFSM",
         	"x": 79,

--- a/Station.json
+++ b/Station.json
@@ -2355,8 +2355,8 @@
         	"group": "2",
         	"name": "Sarreguemines",
         	"ril100": "XFSM",
-        	"x": "79",
-        	"y": "441",
+        	"x": 79,
+        	"y": 441,
 			"platformLength": 270,
         	"platforms": 4,
 			"forRandomTasks": false

--- a/Station.json
+++ b/Station.json
@@ -2272,6 +2272,96 @@
 			"proj": 1
 		},
 		{
+			"group": 2,
+			"name": "Lebach-Jabach",
+			"ril100": "SLCJ",
+			"x": 55,
+			"y": 391,
+			"platformLength": 110,
+			"platforms": 1,
+			"forRandomTasks": false
+		},
+		{
+			"group": 5,
+			"name": "Lebach",
+			"ril100": "SLCH",
+			"x": 57,
+			"y": 391,
+			"platformLength": 110,
+			"platforms": 2,
+			"forRandomTasks": false
+		},
+		{
+        	"group": 2,
+        	"name": "Brebach",
+        	"ril100": "SBA",
+        	"x": 74,
+        	"y": 423,
+        	"platformLength": 78,
+        	"platforms": 2,
+			"forRandomTasks": false
+    	},
+		{
+        	"group": 5,
+        	"name": "Güdingen",
+        	"ril100": "SGD",
+        	"x": 74,
+        	"y": 426,
+        	"platformLength": 100,
+        	"platforms": 2,
+			"forRandomTasks": false
+    	},
+		{
+        	"group": 5,
+        	"name": "Bübingen",
+        	"ril100": "SBN",
+        	"x": 75,
+        	"y": 429,
+        	"platformLength": 199,
+        	"platforms": 2,
+			"forRandomTasks": false
+    	},
+    	{
+        	"group": 2,
+        	"name": "Kleinblittersdorf",
+        	"ril100": "SKB",
+        	"x": 74,
+        	"y": 432,
+        	"platformLength": 88,
+        	"platforms": 3,
+			"forRandomTasks": false
+    	},
+    	{
+        	"group": 5,
+        	"name": "Auersmacher",
+        	"ril100": "SAM",
+        	"x": 76,
+        	"y": 435,
+        	"platformLength": 80,
+        	"platforms": 2,
+			"forRandomTasks": false
+    	},
+    	{
+        	"group": 5,
+        	"name": "Hanweiler-Bad Rilchingen",
+        	"ril100": "SHN",
+        	"x": 77,
+        	"y": 439,
+        	"platformLength": 104,
+        	"platforms": 1,
+			"forRandomTasks": false
+    	},
+    	{
+        	"group": "2",
+        	"name": "Sarreguemines",
+        	"ril100": "XFSM",
+        	"x": "79",
+        	"y": "441",
+			"platformLength": 270,
+        	"platforms": 4,
+			"forRandomTasks": false
+    	},
+		{
 			"name": "Wörth (Isar)",
 			"ril100": "MWTI",
 			"group": 2,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3453,6 +3453,31 @@
 			"stopsEverywhere": true
 		},
 		{
+			"name": "Saarbahn von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe die Regionalstadtbahn der Linie S 1 von %s nach %s.",
+				"Bring die Fahrgäste im Tram-Train pünktlich nach %2$s.",
+				"Fahre die Regionalstadtbahn störungsfrei nach %2$s."
+			],
+			"objects": [
+				{
+					"stations": [ "XFSM", "SKB", "SBA", "SSH", "SLCH" ]
+				},
+				{
+					"stations": [ "SKB", "SBA", "SSH", "SLCH" ]
+				},
+				{
+					"stations": [ "SBA", "SSH", "SLCH", "SLCJ" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "passengers", "value": 0 }
+			],
+			"group": 1,
+			"stopsEverywhere": true
+		},
+		{
 			"name": "Eurotunnel Le Shuttle nach %2$s",
 			"service": 10,
 			"descriptions": [


### PR DESCRIPTION
Fügt die Saarbahn von Lebach-Jabach über Lebach, eine BOStrab-Strecke nach Saarbrücken Hbf und Brebach, Kleinblittersdorf und Hanweiler nach Sarreguemines hinzu.
Mangels Ril-100-Kürzeln gibt es zwischen Lebach und Brebach keine Zwischenhalte außer Saarbrücken Hbf. (Zumindest sind mir keine solchen Kürzel bekannt.)
Das wird leider auch dazu führen, dass in der Übersicht zu den Aufträgen die BOStrab-Anforderung nicht sichtbar sein wird.