### PR TITLE
project_coordinates nicht mehr beim Erstellen neuer Branches, PRs usw. laufen lassen

### DIFF
--- a/.github/workflows/project_coordinates.yml
+++ b/.github/workflows/project_coordinates.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - "Station.json"
-  create:
   workflow_dispatch:
     
 jobs:


### PR DESCRIPTION
Es kann immer noch manuell ausgeführt werden (https://github.com/marhei/TrainCompany-Data/actions/workflows/create_map.yml) und würde derzeit immer noch bei Änderungen an der `Station.json` bei Pushs ausgeführt werden, was vielleicht immer noch stören kann.

(CC @f2k1de)