### PR TITLE
Korrektur der Bezeichnung der M62

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -2430,7 +2430,7 @@
 		{
 			"id": 55628,
 			"group": 0,
-			"name": "MÁV M41/ DR V200",
+			"name": "MÁV M62/ DR V200",
 			"speed": 100,
 			"weight": 115,
 			"force": 295,


### PR DESCRIPTION
Ich hatte für die M62 versehentlich die Bezeichnung der M41 eingegeben.