### PR TITLE
Erweiterung Erzgebirge: Chemnitz-Aue

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -21999,9 +21999,27 @@
 			"objects": [
 				{
 					"start": "DC",
-					"end": "DMW",
-					"length": 17,
+					"end": "DOBL",
+					"length": 8,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "DOBL",
+					"end": "DOF",
+					"length": 3,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "DOF",
+					"end": "DAMD",
+					"length": 4,
 					"twistingFactor": 0.2
+				},
+				{
+					"start": "DAMD",
+					"end": "DMW",
+					"length": 2,
+					"twistingFactor": 0.1
 				},
 				{
 					"start": "DMW",

--- a/Path.json
+++ b/Path.json
@@ -20814,6 +20814,268 @@
 			"length": 7
 		},
 		{
+			"name": "Chemnitz-Aue",
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 80,
+			"twistingFactor": 0.3,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DC",
+					"end": "DCS",
+					"length": 2,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DCS",
+					"end": "DCS S",
+					"length": 1,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "DCS S",
+					"end": "DVTS",
+					"length": 2,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "DVTS",
+					"end": "DCRE",
+					"length": 1,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "DCRE",
+					"end": "DCE",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DCE",
+					"end": "DCEO",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DCEO",
+					"end": "DEDH",
+					"length": 1,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "DEDH",
+					"end": "DED",
+					"length": 1,
+					"maxSpeed": 60
+				},
+				{
+					"start": "DED",
+					"end": "DEDP",
+					"length": 1,
+					"maxSpeed": 60
+				},
+				{
+					"start": "DEDP",
+					"end": "DEDB",
+					"length": 1,
+					"maxSpeed": 60
+				},
+				{
+					"start": "DEDB",
+					"end": "DDF",
+					"length": 2,
+					"maxSpeed": 60
+				},
+				{
+					"start": "DDF",
+					"end": "DKAU",
+					"length": 4,
+					"twistingFactor": 0.4,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DKAU",
+					"end": "DBUF",
+					"length": 2,
+					"twistingFactor": 0.25,
+					"maxSpeed": 70
+				},
+				{
+					"start": "DBUF",
+					"end": "DBUM",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DBUM",
+					"end": "DMS",
+					"length": 3,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DMS",
+					"end": "DTAM",
+					"length": 3,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DTAM",
+					"end": "DTAL",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DTAL",
+					"end": "DDCH",
+					"length": 4,
+					"twistingFactor": 0.35,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DDCH",
+					"end": "DNZW",
+					"length": 2,
+					"twistingFactor": 0.35,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DNZW",
+					"end": "DZI",
+					"length": 3,
+					"twistingFactor": 0.35,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DZI",
+					"end": "DLN",
+					"length": 6,
+					"twistingFactor": 0.5,
+					"maxSpeed": 40
+				},
+				{
+					"start": "DLN",
+					"end": "DLNU",
+					"length": 4,
+					"twistingFactor": 0.45,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DLNU",
+					"end": "DAUS",
+					"length": 3,
+					"twistingFactor": 0.4,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DAUS",
+					"end": "DAU",
+					"length": 2,
+					"twistingFactor": 0.55,
+					"maxSpeed": 50
+				}
+			]
+		},
+		{
+			"name": "Obererzgebirgische Eisenbahn",
+			"electrified": false,
+			"group": 0,
+			"maxSpeed": 100,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DAU",
+					"end": "DLR",
+					"length": 6,
+					"maxSpeed": 70
+				},
+				{
+					"start": "DLR",
+					"end": "DSCN",
+					"length": 2,
+					"twistingFactor": 0.25,
+					"maxSpeed": 80
+				},
+				{
+					"start": "DSCN",
+					"end": "DSC",
+					"length": 2,
+					"twistingFactor": 0.25,
+					"maxSpeed": 80
+				}
+			]
+		},
+		{
+			"name": "Schwarzenberg (Erzgebirge) - Karlovy Vary",
+			"electrified": false,
+			"group": 0,
+			"maxSpeed": 50,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DSC",
+					"end": "DSCH",
+					"length": 2,
+					"maxSpeed": 60,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DSCH",
+					"end": "DERA",
+					"length": 1
+				},
+				{
+					"start": "DERA",
+					"end": "DATL",
+					"length": 4
+				},
+				{
+					"start": "DATL",
+					"end": "DBRE",
+					"length": 3,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "DBRE",
+					"end": "DERB",
+					"length": 3,
+					"maxSpeed": 40,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "DERB",
+					"end": "DJ",
+					"length": 4
+				},
+				{
+					"start": "DJ",
+					"end": "DXJ",
+					"length": 1,
+					"maxSpeed": 60,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DXJ",
+					"end": "XTPO",
+					"length": 1,
+					"maxSpeed": 60,
+					"twistingFactor": 0.1,
+					"neededEquipments": [
+						"DE",
+						"CZ"
+					]
+				}
+			]
+		},
+		{
 			"electrified": true,
 			"group": 0,
 			"maxSpeed": 100,

--- a/Path.json
+++ b/Path.json
@@ -21999,9 +21999,14 @@
 			"objects": [
 				{
 					"start": "DC",
+					"end": "DCKI",
+					"length": 6
+				},
+				{
+					"start": "DCKI",
 					"end": "DOBL",
-					"length": 8,
-					"twistingFactor": 0.25
+					"length": 2,
+					"twistingFactor": 0.2
 				},
 				{
 					"start": "DOBL",

--- a/Path.json
+++ b/Path.json
@@ -21927,6 +21927,81 @@
 			]
 		},
 		{
+			"name": "Obererzgebirgische Eisenbahn",
+			"electrified": false,
+			"group": 0,
+			"maxSpeed": 70,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DZW",
+					"end": "DZSG",
+					"length": 1,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DZSG",
+					"end": "DZWS",
+					"length": 2,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DZWS",
+					"end": "DBAC",
+					"length": 1,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DBAC",
+					"end": "DCDF",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DCDF",
+					"end": "DWI",
+					"length": 2,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "DWI",
+					"end": "DSBS",
+					"length": 4
+				},
+				{
+					"start": "DSBS",
+					"end": "DWSB",
+					"length": 2,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DWSB",
+					"end": "DFBE",
+					"length": 4,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DFBE",
+					"end": "DHST",
+					"length": 3
+				},
+				{
+					"start": "DHST",
+					"end": "DSUB",
+					"length": 5
+				},
+				{
+					"start": "DSUB",
+					"end": "DAU",
+					"length": 4,
+					"twistingFactor": 0.25
+				}
+			]
+		},
+		{
 			"name": "Schwarzenberg (Erzgebirge) - Karlovy Vary",
 			"electrified": false,
 			"group": 0,

--- a/Station.json
+++ b/Station.json
@@ -23191,308 +23191,343 @@
 			"group": 5,
 			"name": "Chemnitz Süd",
 			"ril100": "DCS",
-			"x": 875,
-			"y": 156,
+			"x": 869,
+			"y": 150,
 			"platformLength": 202,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 4,
 			"name": "Chemn Süd Strab",
 			"ril100": "DCS S",
-			"x": 875,
-			"y": 157
+			"x": 869,
+			"y": 151,
+			"proj": 1
 		},
 		{
 			"group": 6,
 			"name": "Chemnitz VTS GmbH",
 			"ril100": "DVTS",
-			"x": 875,
-			"y": 160
+			"x": 869,
+			"y": 154,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Chemnitz-Reichenhain",
 			"ril100": "DCRE",
-			"x": 876,
-			"y": 161,
+			"x": 870,
+			"y": 155,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Chemnitz-Erfenschlag Mitte",
 			"ril100": "DCE",
-			"x": 878,
-			"y": 161,
+			"x": 872,
+			"y": 155,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Chemnitz-Erfenschlag Ost",
 			"ril100": "DCEO",
-			"x": 879,
-			"y": 162,
+			"x": 873,
+			"y": 156,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Einsiedel Gymnasium",
 			"ril100": "DEDH",
-			"x": 881,
-			"y": 163,
+			"x": 875,
+			"y": 157,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Einsiedel",
 			"ril100": "DED",
-			"x": 881,
-			"y": 164,
+			"x": 875,
+			"y": 158,
 			"platformLength": 96,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Einsied Bebel-Pl",
 			"ril100": "DEDP",
-			"x": 881,
-			"y": 165,
+			"x": 875,
+			"y": 159,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Einsiedel Brauerei",
 			"ril100": "DEDB",
-			"x": 881,
-			"y": 166,
+			"x": 875,
+			"y": 160,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Dittersdorf",
 			"ril100": "DDF",
-			"x": 882,
-			"y": 168,
+			"x": 876,
+			"y": 162,
 			"platformLength": 96,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Kemtau",
 			"ril100": "DKAU",
-			"x": 879,
-			"y": 169,
+			"x": 873,
+			"y": 163,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Burkhardtsdorf",
 			"ril100": "DBUF",
-			"x": 876,
-			"y": 171,
+			"x": 870,
+			"y": 165,
 			"platformLength": 98,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Burkhardtsdorf Mitte",
 			"ril100": "DBUM",
-			"x": 874,
-			"y": 171,
+			"x": 868,
+			"y": 165,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Meinersdorf (Erzgebirge)",
 			"ril100": "DMS",
-			"x": 870,
-			"y": 173,
+			"x": 864,
+			"y": 167,
 			"platformLength": 80,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Thalheim Mitte",
 			"ril100": "DTAM",
-			"x": 866,
-			"y": 176,
+			"x": 861,
+			"y": 170,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Thalheim (Erzgebirge)",
 			"ril100": "DTAL",
-			"x": 865,
-			"y": 177,
+			"x": 860,
+			"y": 171,
 			"platformLength": 98,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Dorfchemnitz (bei Zwönitz)",
 			"ril100": "DDCH",
-			"x": 863,
-			"y": 182,
+			"x": 858,
+			"y": 177,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Niederzwönitz",
 			"ril100": "DNZW",
-			"x": 861,
-			"y": 185,
+			"x": 856,
+			"y": 180,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Zwönitz",
 			"ril100": "DZI",
-			"x": 857,
-			"y": 188,
+			"x": 852,
+			"y": 183,
 			"platformLength": 85,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Lößnitz oberer Bahnhof",
 			"ril100": "DLN",
-			"x": 851,
-			"y": 189,
+			"x": 846,
+			"y": 184,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Lößnitz unterer Bahnhof",
 			"ril100": "DLNU",
-			"x": 847,
-			"y": 191,
+			"x": 842,
+			"y": 186,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Aue (Sachsen) Erzgebirgsstadion",
 			"ril100": "DAUS",
-			"x": 845,
-			"y": 194,
+			"x": 841,
+			"y": 189,
 			"platformLength": 190,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 1,
 			"name": "Aue (Sachsen)",
 			"ril100": "DAU",
-			"x": 844,
-			"y": 194,
+			"x": 840,
+			"y": 189,
 			"platformLength": 168,
-			"platforms": 4
+			"platforms": 4,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Lauter (Sachsen)",
 			"ril100": "DLR",
-			"x": 851,
-			"y": 198,
+			"x": 847,
+			"y": 193,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Schwarzenberg-Neuwelt",
 			"ril100": "DSCN",
-			"x": 853,
-			"y": 201,
+			"x": 849,
+			"y": 196,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Schwarzenberg (Erzgebirge)",
 			"ril100": "DSC",
-			"x": 856,
-			"y": 202,
+			"x": 852,
+			"y": 197,
 			"platformLength": 273,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Schwarzenberg (Erzgebirge) Hp",
 			"ril100": "DSCH",
-			"x": 856,
-			"y": 204,
+			"x": 852,
+			"y": 199,
 			"platformLength": 104,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Erla",
 			"ril100": "DERA",
-			"x": 856,
-			"y": 206,
+			"x": 852,
+			"y": 201,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Antonsthal",
 			"ril100": "DATL",
-			"x": 852,
-			"y": 210,
+			"x": 848,
+			"y": 205,
 			"platformLength": 99,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Breitenbrunn (Erzgebirge)",
 			"ril100": "DBRE",
-			"x": 850,
-			"y": 213,
+			"x": 846,
+			"y": 208,
 			"platformLength": 89,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Erlabrunn (Erzgebirge)",
 			"ril100": "DERB",
-			"x": 847,
-			"y": 214,
+			"x": 843,
+			"y": 209,
 			"platformLength": 98,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Johanngeorgenstadt",
 			"ril100": "DJ",
-			"x": 848,
-			"y": 220,
+			"x": 845,
+			"y": 215,
 			"platformLength": 119,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 6,
 			"name": "Johanngeorgenstadt Grenze",
 			"ril100": "DXJ",
-			"x": 849,
-			"y": 221
+			"x": 846,
+			"y": 216,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Potůčky",
 			"ril100": "XTPO",
-			"x": 850,
-			"y": 222
+			"x": 847,
+			"y": 217,
+			"proj": 1
 		},
 		{
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -29203,28 +29203,31 @@
 			"group": 5,
 			"name": "Oberlichtenau",
 			"ril100": "DOBL",
-			"x": 879,
-			"y": 142,
+			"x": 872,
+			"y": 136,
 			"platformLength": 165,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Ottendorf (bei Mittweida)",
 			"ril100": "DOF",
-			"x": 879,
-			"y": 138,
+			"x": 872,
+			"y": 132,
 			"platformLength": 146,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Altmittweida",
 			"ril100": "DAMD",
-			"x": 879,
-			"y": 132,
+			"x": 871,
+			"y": 126,
 			"platformLength": 131,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"name": "Mittweida",

--- a/Station.json
+++ b/Station.json
@@ -24530,7 +24530,7 @@
 			"proj": 1
 		},
 		{
-			"group": 4,
+			"group": 6,
 			"name": "Chemn Süd Strab",
 			"ril100": "DCS S",
 			"x": 869,
@@ -24546,7 +24546,7 @@
 			"proj": 1
 		},
 		{
-			"group": 2,
+			"group": 5,
 			"name": "Chemnitz-Reichenhain",
 			"ril100": "DCRE",
 			"x": 870,

--- a/Station.json
+++ b/Station.json
@@ -24759,87 +24759,97 @@
 			"group": 6,
 			"name": "Zwickau-Schedewitz DB-Grenze",
 			"ril100": "DZSG",
-			"x": 815,
-			"y": 175
+			"x": 810,
+			"y": 171,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Zwickau-Schedewitz",
 			"ril100": "DZWS",
-			"x": 816,
-			"y": 176,
+			"x": 811,
+			"y": 172,
 			"platformLength": 80,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 6,
 			"name": "Cainsdorf Anschluss",
 			"ril100": "DBAC",
-			"x": 816,
-			"y": 178
+			"x": 811,
+			"y": 174,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Cainsdorf",
 			"ril100": "DCDF",
-			"x": 817,
-			"y": 179,
+			"x": 812,
+			"y": 175,
 			"platformLength": 148,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Wilkau-Haßlau",
 			"ril100": "DWI",
-			"x": 819,
-			"y": 180,
+			"x": 814,
+			"y": 176,
 			"platformLength": 110,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Silberstraße",
 			"ril100": "DSBS",
-			"x": 824,
-			"y": 183,
+			"x": 819,
+			"y": 179,
 			"platformLength": 80,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Wiesenburg (Sachsen)",
 			"ril100": "DWSB",
-			"x": 826,
-			"y": 184,
+			"x": 821,
+			"y": 180,
 			"platformLength": 80,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Fährbrücke",
 			"ril100": "DFBE",
-			"x": 833,
-			"y": 185,
+			"x": 828,
+			"y": 180,
 			"platformLength": 80,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Hartenstein",
 			"ril100": "DHST",
-			"x": 838,
-			"y": 184,
+			"x": 833,
+			"y": 179,
 			"platformLength": 100,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Bad Schlema",
 			"ril100": "DSUB",
-			"x": 842,
-			"y": 190,
+			"x": 837,
+			"y": 185,
 			"platformLength": 92,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
@@ -29289,10 +29299,11 @@
 			"group": 5,
 			"name": "Chemnitz Kinderwaldstätte",
 			"ril100": "DCKI",
-			"x": 879,
-			"y": 146,
+			"x": 872,
+			"y": 140,
 			"platformLength": 120,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -29201,6 +29201,15 @@
 		},
 		{
 			"group": 5,
+			"name": "Chemnitz Kinderwaldstätte",
+			"ril100": "DCKI",
+			"x": 879,
+			"y": 146,
+			"platformLength": 120,
+			"platforms": 2
+		},
+		{
+			"group": 5,
 			"name": "Oberlichtenau",
 			"ril100": "DOBL",
 			"x": 872,

--- a/Station.json
+++ b/Station.json
@@ -24756,6 +24756,92 @@
 			"proj": 1
 		},
 		{
+			"group": 6,
+			"name": "Zwickau-Schedewitz DB-Grenze",
+			"ril100": "DZSG",
+			"x": 815,
+			"y": 175
+		},
+		{
+			"group": 5,
+			"name": "Zwickau-Schedewitz",
+			"ril100": "DZWS",
+			"x": 816,
+			"y": 176,
+			"platformLength": 80,
+			"platforms": 2
+		},
+		{
+			"group": 6,
+			"name": "Cainsdorf Anschluss",
+			"ril100": "DBAC",
+			"x": 816,
+			"y": 178
+		},
+		{
+			"group": 5,
+			"name": "Cainsdorf",
+			"ril100": "DCDF",
+			"x": 817,
+			"y": 179,
+			"platformLength": 148,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Wilkau-Haßlau",
+			"ril100": "DWI",
+			"x": 819,
+			"y": 180,
+			"platformLength": 110,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Silberstraße",
+			"ril100": "DSBS",
+			"x": 824,
+			"y": 183,
+			"platformLength": 80,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Wiesenburg (Sachsen)",
+			"ril100": "DWSB",
+			"x": 826,
+			"y": 184,
+			"platformLength": 80,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Fährbrücke",
+			"ril100": "DFBE",
+			"x": 833,
+			"y": 185,
+			"platformLength": 80,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Hartenstein",
+			"ril100": "DHST",
+			"x": 838,
+			"y": 184,
+			"platformLength": 100,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Bad Schlema",
+			"ril100": "DSUB",
+			"x": 842,
+			"y": 190,
+			"platformLength": 92,
+			"platforms": 2
+		},
+		{
 			"group": 5,
 			"name": "Lauter (Sachsen)",
 			"ril100": "DLR",

--- a/Station.json
+++ b/Station.json
@@ -25082,7 +25082,7 @@
 			"proj": 1
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Burgstädt",
 			"ril100": "DBU",
 			"x": 852,

--- a/Station.json
+++ b/Station.json
@@ -29200,6 +29200,33 @@
 			"proj": 1
 		},
 		{
+			"group": 5,
+			"name": "Oberlichtenau",
+			"ril100": "DOBL",
+			"x": 879,
+			"y": 142,
+			"platformLength": 165,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Ottendorf (bei Mittweida)",
+			"ril100": "DOF",
+			"x": 879,
+			"y": 138,
+			"platformLength": 146,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Altmittweida",
+			"ril100": "DAMD",
+			"x": 879,
+			"y": 132,
+			"platformLength": 131,
+			"platforms": 2
+		},
+		{
 			"name": "Mittweida",
 			"ril100": "DMW",
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -23188,6 +23188,313 @@
 			"proj": 1
 		},
 		{
+			"group": 5,
+			"name": "Chemnitz Süd",
+			"ril100": "DCS",
+			"x": 875,
+			"y": 156,
+			"platformLength": 202,
+			"platforms": 3
+		},
+		{
+			"group": 4,
+			"name": "Chemn Süd Strab",
+			"ril100": "DCS S",
+			"x": 875,
+			"y": 157
+		},
+		{
+			"group": 6,
+			"name": "Chemnitz VTS GmbH",
+			"ril100": "DVTS",
+			"x": 875,
+			"y": 160
+		},
+		{
+			"group": 2,
+			"name": "Chemnitz-Reichenhain",
+			"ril100": "DCRE",
+			"x": 876,
+			"y": 161,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Chemnitz-Erfenschlag Mitte",
+			"ril100": "DCE",
+			"x": 878,
+			"y": 161,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Chemnitz-Erfenschlag Ost",
+			"ril100": "DCEO",
+			"x": 879,
+			"y": 162,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Einsiedel Gymnasium",
+			"ril100": "DEDH",
+			"x": 881,
+			"y": 163,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Einsiedel",
+			"ril100": "DED",
+			"x": 881,
+			"y": 164,
+			"platformLength": 96,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Einsied Bebel-Pl",
+			"ril100": "DEDP",
+			"x": 881,
+			"y": 165,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Einsiedel Brauerei",
+			"ril100": "DEDB",
+			"x": 881,
+			"y": 166,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Dittersdorf",
+			"ril100": "DDF",
+			"x": 882,
+			"y": 168,
+			"platformLength": 96,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Kemtau",
+			"ril100": "DKAU",
+			"x": 879,
+			"y": 169,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Burkhardtsdorf",
+			"ril100": "DBUF",
+			"x": 876,
+			"y": 171,
+			"platformLength": 98,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Burkhardtsdorf Mitte",
+			"ril100": "DBUM",
+			"x": 874,
+			"y": 171,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Meinersdorf (Erzgebirge)",
+			"ril100": "DMS",
+			"x": 870,
+			"y": 173,
+			"platformLength": 80,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Thalheim Mitte",
+			"ril100": "DTAM",
+			"x": 866,
+			"y": 176,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Thalheim (Erzgebirge)",
+			"ril100": "DTAL",
+			"x": 865,
+			"y": 177,
+			"platformLength": 98,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Dorfchemnitz (bei Zwönitz)",
+			"ril100": "DDCH",
+			"x": 863,
+			"y": 182,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Niederzwönitz",
+			"ril100": "DNZW",
+			"x": 861,
+			"y": 185,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Zwönitz",
+			"ril100": "DZI",
+			"x": 857,
+			"y": 188,
+			"platformLength": 85,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Lößnitz oberer Bahnhof",
+			"ril100": "DLN",
+			"x": 851,
+			"y": 189,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Lößnitz unterer Bahnhof",
+			"ril100": "DLNU",
+			"x": 847,
+			"y": 191,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Aue (Sachsen) Erzgebirgsstadion",
+			"ril100": "DAUS",
+			"x": 845,
+			"y": 194,
+			"platformLength": 190,
+			"platforms": 1
+		},
+		{
+			"group": 1,
+			"name": "Aue (Sachsen)",
+			"ril100": "DAU",
+			"x": 844,
+			"y": 194,
+			"platformLength": 168,
+			"platforms": 4
+		},
+		{
+			"group": 5,
+			"name": "Lauter (Sachsen)",
+			"ril100": "DLR",
+			"x": 851,
+			"y": 198,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Schwarzenberg-Neuwelt",
+			"ril100": "DSCN",
+			"x": 853,
+			"y": 201,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Schwarzenberg (Erzgebirge)",
+			"ril100": "DSC",
+			"x": 856,
+			"y": 202,
+			"platformLength": 273,
+			"platforms": 3
+		},
+		{
+			"group": 5,
+			"name": "Schwarzenberg (Erzgebirge) Hp",
+			"ril100": "DSCH",
+			"x": 856,
+			"y": 204,
+			"platformLength": 104,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Erla",
+			"ril100": "DERA",
+			"x": 856,
+			"y": 206,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Antonsthal",
+			"ril100": "DATL",
+			"x": 852,
+			"y": 210,
+			"platformLength": 99,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Breitenbrunn (Erzgebirge)",
+			"ril100": "DBRE",
+			"x": 850,
+			"y": 213,
+			"platformLength": 89,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Erlabrunn (Erzgebirge)",
+			"ril100": "DERB",
+			"x": 847,
+			"y": 214,
+			"platformLength": 98,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Johanngeorgenstadt",
+			"ril100": "DJ",
+			"x": 848,
+			"y": 220,
+			"platformLength": 119,
+			"platforms": 3
+		},
+		{
+			"group": 6,
+			"name": "Johanngeorgenstadt Grenze",
+			"ril100": "DXJ",
+			"x": 849,
+			"y": 221
+		},
+		{
+			"group": 2,
+			"name": "Potůčky",
+			"ril100": "XTPO",
+			"x": 850,
+			"y": 222
+		},
+		{
 			"group": 2,
 			"name": "Borsdorf (Sachsen)",
 			"ril100": "LBOR",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2243,6 +2243,20 @@
 		},
 		{
 			"group": 1,
+			"name": "ČD von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Aufgrund von Bauarbeiten auf der Strecke ČD 142 erfolgt die Weiterfahrt von Potůčky nach mit dem Schienenersatzverkehr",
+				"Wenn die Bauarbeiten auf der Strecke ČD 142 abgeschlossen sind, kann man wieder ohne umzusteigen von Johanngeorgenstadt nach Karlovy Vary fahren."
+			],
+			"stations": [ "DJ", "XTPO" ],
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"name": "CB C13 von %s nach %s",
 			"service": 3,
 			"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2247,9 +2247,26 @@
 			"service": 3,
 			"descriptions": [
 				"Fahre mit der Chemnitzer City-Bahn von %s nach %s",
-				"Die Tramhaltestellen Bahnhofstraße bis Technopark werden heute nicht bedient."
+				"Die Tramhaltestellen Bahnhofstraße bis Technopark werden heute nicht bedient.",
+				"Fahre die CB C13 durchs beschauliche Zwönitztal.",
+				"Zwei mal im Monat ist der Zug voll mit Fußballfans."
 			],
 			"stations": [ "DBU", "DC", "DED", "DDF", "DBUF", "DMS", "DTAL", "DZI", "DAU" ],
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "CB C14 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre mit der Chemnitzer City-Bahn von %s nach %s",
+				"Die Tramhaltestellen Bahnhofstraße bis Technopark werden heute nicht bedient.",
+				"Normalerweise kommen auf dieser Strecke Mehrsystemfahrzeuge vom Typ Citylink zum Einsatz."
+			],
+			"stations": [ "DMW", "DC", "DED", "DDF", "DBUF", "DMS", "DTAL" ],
 			"stopsEverwhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2243,6 +2243,20 @@
 		},
 		{
 			"group": 1,
+			"name": "CB C13 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre mit der Chemnitzer City-Bahn von %s nach %s",
+				"Die Tramhaltestellen Bahnhofstraße bis Technopark werden heute nicht bedient."
+			],
+			"stations": [ "DBU", "DC", "DED", "DDF", "DBUF", "DMS", "DTAL", "DZI", "DAU" ],
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"name": "RB 91 von %s nach %s",
 			"service": 3,
 			"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2227,6 +2227,22 @@
 		},
 		{
 			"group": 1,
+			"name": "RB 95 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre den RB 95 auf der Obererzgebirgischen Eisenbahn von %s nach %s.",
+				"Auch das Erzgebirge ist bei Urlaubern beliebt.",
+				"Das Muldetal ist mit dem RB 95 zu erreichen.",
+				"Mit dem RB 95 kommt man nah an die tschechische Grenze."
+			],
+			"stations": [ "DZW", "DAU", "DSC", "DJ" ],
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"name": "RB 91 von %s nach %s",
 			"service": 3,
 			"descriptions": [


### PR DESCRIPTION
Teil von #481 

- [x] Stationen Chemnitz - Aue
- [x] Stationen Aue - Schwarzenberg (Erzgebirge)
- [x] Stationen Schwarzenberg - Johanngeorgenstadt - Potůčky
- [x] Route Chemnitz - Aue
- [x] Route Aue - Schwarzenberg (Erzgebirge)
- [x] Route  Schwarzenberg (Erzgebirge) - Johanngeorgenstadt - Potůčky
- [x] overhaul Chemnitz - Mittweida
- [x] overhaul Burgstädt - Chemnitz (promote to Bhf damit Linen da anfangen/enden dürfen, insb. CB C13)
- [x] Strecke Zwickau-Aue
- [x] Auftrag RB95 Zwickau-Aue-Schwarzenberg-Johanngeorgenstadt
- [x] Auftrag CB C13 (Chemnitzer Citybahn) Aue - Thalheim - Dittersdorf - Chemnitz Reichenhain (ab da als TRAM weiter nach Chemnitz Hbf - dann da wieder auf "richtiger Strecke" bis Burgstädt) - im Orignal besetzt durch [Citylink](https://www.city-bahn.de/de/Daten_Fakten/Fahrzeuge/Citylink_1182.html?sid=g24aAGuOaBuG4KLS2NWfhqSZJdIddaQl) (⚡️, ⛽️, BOStrab, EBO), siehe auch [Liniennetzplan](https://www.city-bahn.de/csdata/download/4/de/cbc_liniennetzplan_02_2022_7664.pdf)
- [x] Auftrag CB C14  (Chemnitzer Citybahn) Mittweida (bis hier EBO) - (ab hier BOSTtrab) Chemnitz Hbf - (ab hier EBO) Chemnitz Reichenhain - Dittersdorf - Thalheim
- [x] optional Auftrag České dráhy Os 17107/17104 (Johanngeorgenstadt - Potůčky - Horni Blatna - Nejdek - Karlovy Vary)
- ~~optional Straßenbahn Haltepunkte (und Wendeschleifen) sofern für CB 14 / CB 14 benutzt~~
