### PR TITLE
Anpassung Holzzugauftrag aus Rottleberode

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3853,9 +3853,9 @@
 				"Der Holzproduzent Ante möchte Schnittholz aus %s zur Europalettenproduktion nach %s liefern lassen.",
 				"Es wird Holz aus %s für die Europalettenproduktion in %s benötigt."
 			],
-			"stations": [ "URTS", "TMG" ],
+			"stations": [ "URTS" ],
 			"neededCapacity": [
-				{ "name": "wood", "value": 800 }
+				{ "name": "wood", "value": 1800 }
 			]
 		},
 		{


### PR DESCRIPTION
Anpassung der geforderten Kapazität, damit sie der von 30 Wagen entspricht. (Diese Anzahl wird im verlinkten Artikel genannt.)
https://www.thueringer-allgemeine.de/regionen/nordhausen/holzproduzent-aus-rottleberode-will-immer-mehr-auf-die-schiene-verlagern-id236063263.html
(30 * 60t = 1800 t; mit 30 * 20m = 600m auch kein Problem mit der Längenbegrenzung.)

Außerdem das feste Ziel entfernt. Der Holzproduzent hat wohl eh mehrere Kunden und in der festen Kombination kam der Auftrag natürlich auch mal in der falschen Richtung...