### PR TITLE
fix Miltitz-Roitzschen x-coord

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -27845,8 +27845,8 @@
 			"group": 2,
 			"name": "Miltitz-Roitzschen",
 			"ril100": "DMI",
-			"x": 956,
-			"y": 97,
+			"x": 936,
+			"y": 102,
 			"platformLength": 233,
 			"platforms": 1,
 			"proj": 1


### PR DESCRIPTION
related to #479

Problem war Miltitz-Roitzschen (DMI) da hatte ich falsch interpoliert (x/y offset vertauscht).