### PR TITLE
Nebenbahn Flöha - Annaberg-Buchholz (-Vejprty (CZ))

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -21982,6 +21982,161 @@
 			"length": 7
 		},
 		{
+			"name": "Zschopautalbahn",
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 80,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DFL",
+					"end": "DFLP",
+					"length": 1,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "DFLP",
+					"end": "DEA",
+					"length": 3,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DEA",
+					"end": "DHRF",
+					"length": 4
+				},
+				{
+					"start": "DHRF",
+					"end": "DWIT",
+					"length": 3
+				},
+				{
+					"start": "DWIT",
+					"end": "DWK",
+					"length": 1,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DWK",
+					"end": "DZPO",
+					"length": 3,
+					"maxSpeed": 70
+				},
+				{
+					"start": "DZPO",
+					"end": "DZP",
+					"length": 1
+				},
+				{
+					"start": "DZP",
+					"end": "DWL",
+					"length": 3,
+					"maxSpeed": 70
+				},
+				{
+					"start": "DWL",
+					"end": "DSS",
+					"length": 3,
+					"maxSpeed": 50,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "DSS",
+					"end": "DWAB",
+					"length": 4
+				},
+				{
+					"start": "DWAB",
+					"end": "DWO",
+					"maxSpeed": 50,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "DWO",
+					"end": "DWIE",
+					"length": 6,
+					"maxSpeed": 60
+				},
+				{
+					"start": "DWIE",
+					"end": "DWIS",
+					"length": 2,
+					"maxSpeed": 50
+				},
+				{
+					"start": "DWIS",
+					"end": "DABU",
+					"length": 6,
+					"maxSpeed": 60
+				}
+			]
+		},
+		{
+			"name": "Vejprty–Annaberg-Buchholz unt Bf",
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 60,
+			"twistingFactor": 0.3,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DABU",
+					"end": "DABM",
+					"length": 1
+				},
+				{
+					"start": "DABM",
+					"end": "DAB",
+					"length": 1
+				}
+			]
+		},
+		{
+			"name": "Vejprty–Annaberg-Buchholz unt Bf",
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 50,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DAB",
+					"end": "DSEH",
+					"length": 3,
+					"maxSpeed": 60,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DSEH",
+					"end": "DCR",
+					"length": 3
+				},
+				{
+					"start": "DCR",
+					"end": "DBS",
+					"length": 10,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "DBS",
+					"end": "XTVY",
+					"length": 1,
+					"maxSpeed": 60,
+					"twistingFactor": 0.2,
+					"neededEquipments": [
+						"DE","CZ"
+					]
+				}
+			]
+		},
+		{
 			"name": "Chemnitz-Aue",
 			"electrified": false,
 			"group": 1,

--- a/Path.json
+++ b/Path.json
@@ -19683,29 +19683,57 @@
 				},
 				{
 					"start": "DFR",
+					"end": "DKMA",
+					"length": 6,
+					"maxSpeed": 100,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "DKMA",
 					"end": "DFRS",
-					"length": 9,
-					"maxSpeed": 120
+					"length": 4,
+					"maxSpeed": 120,
+					"twistingFactor": 0.3
 				},
 				{
 					"start": "DFRS",
+					"end": "DOR",
+					"length": 7,
+					"maxSpeed": 110
+				},
+				{
+					"start": "DOR",
 					"end": "DFUS",
-					"length": 13,
+					"length": 7,
 					"maxSpeed": 90
 				},
 				{
 					"start": "DFUS",
+					"end": "DFL",
+					"length": 3,
+					"maxSpeed": 80,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DFL",
 					"end": "DNR",
-					"length": 6,
-					"maxSpeed": 100,
+					"length": 4,
+					"maxSpeed": 120,
 					"twistingFactor": 0.2
 				},
 				{
 					"start": "DNR",
-					"end": "DC",
-					"length": 8,
+					"end": "DCHP",
+					"length": 5,
 					"maxSpeed": 120,
 					"twistingFactor": 0.2
+				},
+				{
+					"start": "DCHP",
+					"end": "DC",
+					"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.3
 				},
 				{
 					"start": "DC",

--- a/Path.json
+++ b/Path.json
@@ -22335,6 +22335,65 @@
 			]
 		},
 		{
+			"name": "Annaberg-Buchholz–Schwarzenberg",
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 50,
+			"twistingFactor": 0.4,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "DAB",
+					"end": "DWF",
+					"length": 5
+				},
+				{
+					"start": "DWF",
+					"end": "DSCL",
+					"length": 2
+				},
+				{
+					"start": "DSCL",
+					"end": "DSG",
+					"length": 3
+				},
+				{
+					"start": "DSG",
+					"end": "DMAR",
+					"length": 8,
+					"maxSpeed": 40,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "DMAR",
+					"end": "DRAS",
+					"length": 1,
+					"maxSpeed": 40
+				},
+				{
+					"start": "DRAS",
+					"end": "DGS",
+					"length": 2,
+					"maxSpeed": 40
+				},
+				{
+					"start": "DGS",
+					"end": "DSCP",
+					"length": 1,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "DSCP",
+					"end": "DSC",
+					"length": 2,
+					"maxSpeed": 60,
+					"twistingFactor": 0.2
+				}
+			]
+		},
+		{
 			"name": "Obererzgebirgische Eisenbahn",
 			"electrified": false,
 			"group": 0,

--- a/Path.json
+++ b/Path.json
@@ -22051,6 +22051,7 @@
 				{
 					"start": "DWAB",
 					"end": "DWO",
+					"length": 3,
 					"maxSpeed": 50,
 					"twistingFactor": 0.45
 				},

--- a/Station.json
+++ b/Station.json
@@ -24695,6 +24695,184 @@
 		},
 		{
 			"group": 5,
+			"name": "Flöha-Plaue",
+			"ril100": "DFLP",
+			"x": 896,
+			"y": 152,
+			"platformLength": 81,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Erdmannsdorf-Augustusburg",
+			"ril100": "DEA",
+			"x": 896,
+			"y": 156,
+			"platformLength": 75,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Hennersdorf (Sachsen)",
+			"ril100": "DHRF",
+			"x": 895,
+			"y": 161,
+			"platformLength": 79,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Witzschdorf",
+			"ril100": "DWIT",
+			"x": 897,
+			"y": 164,
+			"platformLength": 81,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Waldkirchen (Erzgebirge)",
+			"ril100": "DWK",
+			"x": 897,
+			"y": 166,
+			"platformLength": 77,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Zschopau Ost",
+			"ril100": "DZPO",
+			"x": 896,
+			"y": 169,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Zschopau",
+			"ril100": "DZP",
+			"x": 894,
+			"y": 169,
+			"platformLength": 112,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Wilischthal",
+			"ril100": "DWL",
+			"x": 893,
+			"y": 172,
+			"platformLength": 78,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Scharfenstein",
+			"ril100": "DSS",
+			"x": 893,
+			"y": 176,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Warmbad",
+			"ril100": "DWAB",
+			"x": 894,
+			"y": 182,
+			"platformLength": 79,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Wolkenstein",
+			"ril100": "DWO",
+			"x": 894,
+			"y": 184,
+			"platformLength": 112,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Thermalbad Wiesenbad",
+			"ril100": "DWIE",
+			"x": 891,
+			"y": 190,
+			"platformLength": 81,
+			"platforms": 1
+		},
+		{
+			"group": 5,
+			"name": "Wiesa (Erzgebirge)",
+			"ril100": "DWIS",
+			"x": 888,
+			"y": 191,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Annaberg-Buchholz (unterer Bahnhof)",
+			"ril100": "DABU",
+			"x": 885,
+			"y": 196,
+			"platformLength": 100,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Annaberg-Buchholz Mitte",
+			"ril100": "DABM",
+			"x": 885,
+			"y": 198,
+			"platformLength": 80,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Annaberg-Buchholz Süd",
+			"ril100": "DAB",
+			"x": 885,
+			"y": 200,
+			"platformLength": 84,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Sehma",
+			"ril100": "DSEH",
+			"x": 884,
+			"y": 204,
+			"platformLength": 72,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Cranzahl",
+			"ril100": "DCR",
+			"x": 884,
+			"y": 208,
+			"platformLength": 100,
+			"platforms": 3
+		},
+		{
+			"group": 5,
+			"name": "Bärenstein (Kreis Annaberg)",
+			"ril100": "DBS",
+			"x": 889,
+			"y": 208
+		},
+		{
+			"group": 2,
+			"name": "Vejprty",
+			"ril100": "XTVY",
+			"x": 890,
+			"y": 210,
+			"platformLength": 170,
+			"platforms": 4
+		},
+		{
+			"group": 5,
 			"name": "Oederan",
 			"ril100": "DOR",
 			"x": 902,

--- a/Station.json
+++ b/Station.json
@@ -24674,6 +24674,42 @@
 			"proj": 1
 		},
 		{
+			"group": 5,
+			"name": "Chemnitz-Hilbersdorf Hp",
+			"ril100": "DCHP",
+			"x": 879,
+			"y": 150,
+			"platformLength": 115,
+			"platforms": 2
+		},
+		{
+			"group": 1,
+			"name": "Flöha",
+			"ril100": "DFL",
+			"x": 895,
+			"y": 151,
+			"platformLength": 178,
+			"platforms": 6
+		},
+		{
+			"group": 5,
+			"name": "Oederan",
+			"ril100": "DOR",
+			"x": 909,
+			"y": 150,
+			"platformLength": 170,
+			"platforms": 2
+		},
+		{
+			"group": 5,
+			"name": "Kleinschirma",
+			"ril100": "DKMA",
+			"x": 923,
+			"y": 143,
+			"platformLength": 104,
+			"platforms": 2
+		},
+		{
 			"name": "Freiberg (Sachs)",
 			"ril100": "DFR",
 			"group": 2,
@@ -24696,7 +24732,7 @@
 		{
 			"name": "Falkenau (Sachs) Süd",
 			"ril100": "DFUS",
-			"group": 2,
+			"group": 5,
 			"x": 893,
 			"y": 145,
 			"platformLength": 120,

--- a/Station.json
+++ b/Station.json
@@ -25327,62 +25327,69 @@
 			"group": 5,
 			"name": "Walthersdorf (Erzgebirge)",
 			"ril100": "DWF",
-			"x": 880,
-			"y": 202,
+			"x": 876,
+			"y": 196,
 			"platformLength": 56,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Schlettau (Erzgebirge)",
 			"ril100": "DSCL",
-			"x": 879,
-			"y": 200,
+			"x": 875,
+			"y": 194,
 			"platformLength": 120,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Scheibenberg",
 			"ril100": "DSG",
-			"x": 873,
-			"y": 202,
+			"x": 869,
+			"y": 196,
 			"platformLength": 75,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Markersbach (Erzgebirge)",
 			"ril100": "DMAR",
-			"x": 866,
-			"y": 204,
+			"x": 862,
+			"y": 198,
 			"platformLength": 146,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Raschau (bei Schwarzenberg)",
 			"ril100": "DRAS",
-			"x": 863,
-			"y": 204,
+			"x": 859,
+			"y": 199,
 			"platformLength": 120,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Grünstädtel",
 			"ril100": "DGS",
-			"x": 860,
-			"y": 205,
+			"x": 856,
+			"y": 200,
 			"platformLength": 154,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 6,
 			"name": "Schwarzenberg Erzgeb Pappen-u Kartonagen",
 			"ril100": "DSCP",
-			"x": 858,
-			"y": 203
+			"x": 854,
+			"y": 198,
+			"proj": 1
 		},
 		{
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -24697,179 +24697,199 @@
 			"group": 5,
 			"name": "Flöha-Plaue",
 			"ril100": "DFLP",
-			"x": 896,
-			"y": 152,
+			"x": 889,
+			"y": 146,
 			"platformLength": 81,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Erdmannsdorf-Augustusburg",
 			"ril100": "DEA",
-			"x": 896,
-			"y": 156,
+			"x": 889,
+			"y": 150,
 			"platformLength": 75,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Hennersdorf (Sachsen)",
 			"ril100": "DHRF",
-			"x": 895,
-			"y": 161,
+			"x": 889,
+			"y": 155,
 			"platformLength": 79,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Witzschdorf",
 			"ril100": "DWIT",
-			"x": 897,
-			"y": 164,
+			"x": 891,
+			"y": 157,
 			"platformLength": 81,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Waldkirchen (Erzgebirge)",
 			"ril100": "DWK",
-			"x": 897,
-			"y": 166,
+			"x": 891,
+			"y": 159,
 			"platformLength": 77,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Zschopau Ost",
 			"ril100": "DZPO",
-			"x": 896,
-			"y": 169,
+			"x": 890,
+			"y": 163,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Zschopau",
 			"ril100": "DZP",
-			"x": 894,
-			"y": 169,
+			"x": 888,
+			"y": 163,
 			"platformLength": 112,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Wilischthal",
 			"ril100": "DWL",
-			"x": 893,
-			"y": 172,
+			"x": 887,
+			"y": 166,
 			"platformLength": 78,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Scharfenstein",
 			"ril100": "DSS",
-			"x": 893,
-			"y": 176,
+			"x": 887,
+			"y": 170,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Warmbad",
 			"ril100": "DWAB",
-			"x": 894,
-			"y": 182,
+			"x": 889,
+			"y": 176,
 			"platformLength": 79,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Wolkenstein",
 			"ril100": "DWO",
-			"x": 894,
-			"y": 184,
+			"x": 889,
+			"y": 178,
 			"platformLength": 112,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Thermalbad Wiesenbad",
 			"ril100": "DWIE",
-			"x": 891,
-			"y": 190,
+			"x": 886,
+			"y": 184,
 			"platformLength": 81,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Wiesa (Erzgebirge)",
 			"ril100": "DWIS",
-			"x": 888,
-			"y": 191,
+			"x": 883,
+			"y": 185,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Annaberg-Buchholz (unterer Bahnhof)",
 			"ril100": "DABU",
-			"x": 885,
-			"y": 196,
+			"x": 881,
+			"y": 190,
 			"platformLength": 100,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Annaberg-Buchholz Mitte",
 			"ril100": "DABM",
-			"x": 885,
-			"y": 198,
+			"x": 881,
+			"y": 192,
 			"platformLength": 80,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Annaberg-Buchholz Süd",
 			"ril100": "DAB",
-			"x": 885,
-			"y": 200,
+			"x": 881,
+			"y": 194,
 			"platformLength": 84,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Sehma",
 			"ril100": "DSEH",
-			"x": 884,
-			"y": 204,
+			"x": 880,
+			"y": 198,
 			"platformLength": 72,
-			"platforms": 1
+			"platforms": 1,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Cranzahl",
 			"ril100": "DCR",
-			"x": 884,
-			"y": 208,
+			"x": 880,
+			"y": 202,
 			"platformLength": 100,
-			"platforms": 3
+			"platforms": 3,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Bärenstein (Kreis Annaberg)",
 			"ril100": "DBS",
-			"x": 889,
-			"y": 208
+			"x": 885,
+			"y": 202,
+			"proj": 1
 		},
 		{
 			"group": 2,
 			"name": "Vejprty",
 			"ril100": "XTVY",
-			"x": 890,
-			"y": 210,
+			"x": 886,
+			"y": 204,
 			"platformLength": 170,
-			"platforms": 4
+			"platforms": 4,
+			"proj": 1
 		},
 		{
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -25325,6 +25325,67 @@
 		},
 		{
 			"group": 5,
+			"name": "Walthersdorf (Erzgebirge)",
+			"ril100": "DWF",
+			"x": 880,
+			"y": 202,
+			"platformLength": 56,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Schlettau (Erzgebirge)",
+			"ril100": "DSCL",
+			"x": 879,
+			"y": 200,
+			"platformLength": 120,
+			"platforms": 3
+		},
+		{
+			"group": 5,
+			"name": "Scheibenberg",
+			"ril100": "DSG",
+			"x": 873,
+			"y": 202,
+			"platformLength": 75,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Markersbach (Erzgebirge)",
+			"ril100": "DMAR",
+			"x": 866,
+			"y": 204,
+			"platformLength": 146,
+			"platforms": 3
+		},
+		{
+			"group": 5,
+			"name": "Raschau (bei Schwarzenberg)",
+			"ril100": "DRAS",
+			"x": 863,
+			"y": 204,
+			"platformLength": 120,
+			"platforms": 1
+		},
+		{
+			"group": 2,
+			"name": "Grünstädtel",
+			"ril100": "DGS",
+			"x": 860,
+			"y": 205,
+			"platformLength": 154,
+			"platforms": 1
+		},
+		{
+			"group": 6,
+			"name": "Schwarzenberg Erzgeb Pappen-u Kartonagen",
+			"ril100": "DSCP",
+			"x": 858,
+			"y": 203
+		},
+		{
+			"group": 5,
 			"name": "Schwarzenberg (Erzgebirge) Hp",
 			"ril100": "DSCH",
 			"x": 852,

--- a/Station.json
+++ b/Station.json
@@ -24677,37 +24677,41 @@
 			"group": 5,
 			"name": "Chemnitz-Hilbersdorf Hp",
 			"ril100": "DCHP",
-			"x": 879,
-			"y": 150,
+			"x": 872,
+			"y": 144,
 			"platformLength": 115,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 1,
 			"name": "Flöha",
 			"ril100": "DFL",
-			"x": 895,
-			"y": 151,
+			"x": 888,
+			"y": 145,
 			"platformLength": 178,
-			"platforms": 6
+			"platforms": 6,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Oederan",
 			"ril100": "DOR",
-			"x": 909,
-			"y": 150,
+			"x": 902,
+			"y": 143,
 			"platformLength": 170,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"group": 5,
 			"name": "Kleinschirma",
 			"ril100": "DKMA",
-			"x": 923,
-			"y": 143,
+			"x": 915,
+			"y": 136,
 			"platformLength": 104,
-			"platforms": 2
+			"platforms": 2,
+			"proj": 1
 		},
 		{
 			"name": "Freiberg (Sachs)",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2263,6 +2263,21 @@
 			]
 		},
 		{
+			"group": 0,
+			"service": 4,
+			"name": "Erzgebirgische Aussichtsbahn",
+			"descriptions": [
+				"Es ist wieder soweit, an diesem Wochenende soll ein Sonderzug auf dieser sonst wenig befahrenen Strecke verkehren.",
+				"Der Verein Sächsischer Eisenbahnfreunde würde historische Fahrzeuge für diesen Sonderzug bevorzugen.",
+				"Daß das advanced TrainLab auf dieser Strecke fuhr, ist schon einige Zeit her. Heute sollte es etwas klassischer zugehen. "
+			],
+			"stations": [ "DABU", "DAB", "DSCL", "DMAR", "DGS", "DSC" ],
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
 			"group": 1,
 			"name": "ČD von %s nach %s",
 			"service": 3,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3569,7 +3569,7 @@
 				"Bring die Fahrgäste in dem RE 3 pünktlich nach %2$s.",
 				"Fahre den RE störungsfrei nach %2$s."
 			],
-			"stations": [ "DH", "DTH", "DFR", "DNR", "DC", "DHO", "DGL", "DZW", "DRC", "DP", "NHO" ],
+			"stations": [ "DH", "DTH", "DFR", "DFL", "DNR", "DC", "DHO", "DGL", "DZW", "DRC", "DP", "NHO" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			],
@@ -3583,7 +3583,7 @@
 				"Bring die Fahrgäste in der RB 30 pünktlich nach %2$s.",
 				"Fahre die RB störungsfrei nach %2$s."
 			],
-			"stations": [ "DH", "DTH", "DFR", "DNR", "DC", "DHO", "DGL", "DZW" ],
+			"stations": [ "DH", "DTH", "DFR", "DFL", "DNR", "DC", "DHO", "DGL", "DZW" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			],

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2227,6 +2227,27 @@
 		},
 		{
 			"group": 1,
+			"name": "RB 80 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre den RB 80 durch das Zschopautal von %s nach %s.",
+				"Auch das Erzgebirge ist bei Urlaubern beliebt.",
+				"Die Burg Scharfenstein ist mit dem RB 80 zu erreichen.",
+				"Besichtigen Sie das Wolkensteiner Schloß und übernachten Sie im Zughotel.",
+				"In der Saison verkehrt der RB 80 bis ins tschechische Chomutov."
+			],
+			"objects": [
+				{"stations": [ "DC", "DNR", "DFL", "DNRF", "DZP", "DWO", "DABU", "DAB" ]},
+				{"stations": [ "DC", "DNR", "DFL", "DNRF", "DZP", "DWO", "DABU", "DAB", "DCR" ]},
+				{"stations": [ "DCR", "XTVY" ]}
+			],			
+			"stopsEverwhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"name": "RB 95 von %s nach %s",
 			"service": 3,
 			"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2237,8 +2237,8 @@
 				"In der Saison verkehrt der RB 80 bis ins tschechische Chomutov."
 			],
 			"objects": [
-				{"stations": [ "DC", "DNR", "DFL", "DNRF", "DZP", "DWO", "DABU", "DAB" ]},
-				{"stations": [ "DC", "DNR", "DFL", "DNRF", "DZP", "DWO", "DABU", "DAB", "DCR" ]},
+				{"stations": [ "DC", "DNR", "DFL", "DHRF", "DZP", "DWO", "DABU", "DAB" ]},
+				{"stations": [ "DC", "DNR", "DFL", "DHRF", "DZP", "DWO", "DABU", "DAB", "DCR" ]},
 				{"stations": [ "DCR", "XTVY" ]}
 			],			
 			"stopsEverwhere": true,


### PR DESCRIPTION
part of #481

- [x] overhaul Chemitz-Freiberg (insert Flöha)
- [x] update route suggestions for jobs between Chemnitz and Dresden
- [x] add stations Flöha - Annaberg-Buchholz
- [x] add route Flöha - Annaberg-Buchholz
- [x] add stations Annaberg-Buchholz - Vejprty (CZ)
- [x] add route Annaberg-Buchholz - Vejprty (CZ)
- [x] add stations Annaberg-Buchholz - Schwarzenberg
- [x] add route Annaberg-Buchholz - Schwarzenberg
- [x] add job RB 80 Chemnitz - Flöha - Zschopau - Annaberg-Buchholz - (Cranzahl) - (Vejprty) - (Chomutov)
- [x] add job Direktvergabe Sonderfahrt Erzgebirgische Aussichtsbahn Annaberg-Buchholz - Schwarzenberg