### PR TITLE
Fix some pathSuggestions

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -454,7 +454,7 @@
 			"objects": [
 				{
 					"stations": [ "XSZH", "XSB", "XFMV", "XFD", "XFPO" ],
-					"pathSuggestion": [ "XSZH", "XSKS", "XSB", "XFMV", "🇫🇷GLS", "XFBTV", "XFD", "🇫🇷PAI", "🇫🇷MOIS", "XFPO" ]
+					"pathSuggestion": [ "XSZH", "XSKS", "XSB", "XFMV", "XFBTV", "🇫🇷GLS", "XFD", "🇫🇷PAI", "🇫🇷MOIS", "XFPO" ]
 				},
 				{
 					"stations": [ "XSZH", "XSB", "XFMV", "XFBMT", "XFPO" ],
@@ -1629,11 +1629,11 @@
 			"objects": [
 				{
 					"stations": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASR", "XASK", "XASB" ],
-					"pathSuggestion": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASR", "XASK", "XASF", "XASB" ]
+					"pathSuggestion": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASR", "XASF", "XASK", "XASB" ]
 				},
 				{
 					"stations": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASR", "XASK", "XASB", "MH" ],
-					"pathSuggestion": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASF", "XASR", "XASK", "XASB", "MFL", "MTS", "MRO", "MGB", "MH" ]
+					"pathSuggestion": [ "XAWW", "XAP", "XAAS", "XAL", "XAWE", "XAAT", "XAVB", "XASR", "XASF", "XASK", "XASB", "MFL", "MTS", "MRO", "MGB", "MH" ]
 				}
 			],
 			"stopsEverywhere": false,
@@ -4331,7 +4331,7 @@
 			"objects": [
 				{
 					"stations": [ "XASB", "MFL", "MPR", "MRO", "MH", "NN", "AH", "AHI", "AHM", "ANB", "AWLA" ],
-					"pathSuggestion": [ "XASB", "MFL", "MPR", "MTS", "MRO", "MGB", "MH", "MDA", "MIH", "NN", "NF", "NRTD", "NWH", "NRB", "NBN", "FFU", "FKW", "HG", "HH", "HU", "ALBG", "AHAR", "AH", "AEL", "AHI", "AHM", "ANB", "AWLA" ]
+					"pathSuggestion": [ "XASB", "MFL", "MTS", "MPR", "MRO", "MGB", "MH", "MDA", "MIH", "NN", "NF", "NRTD", "NWH", "NRB", "NBN", "FFU", "FKW", "HG", "HH", "HU", "ALBG", "AHAR", "AH", "AEL", "AHI", "AHM", "ANB", "AWLA" ]
 				},
 				{
 					"stations": [ "RB", "RF", "RK", "RM", "FF", "AH", "AHI", "AHM", "ANB", "AWLA" ],
@@ -4535,7 +4535,7 @@
 			"objects": [
 				{
 					"stations": [ "XEMAT", "XEB", "XFM", "XIMB", "XSZH", "XAND", "XAWE", "BL" ],
-					"pathSuggestion": [ "XEMAT", "XEB", "XFNB", "🇫🇷VLM", "🇫🇷MHV", "🇫🇷NPG", "XFARL", "XFM", "XIAQ", "XITOR", "XIMB", "XSBZ", "XSBC", "XSADF", "XSAG", "XSTW", "XSZH", "XSZO", "XSSG", "XSSM", "XSBU", "XAND", "XAFK", "XAI", "🇦🇹Fw Z2", "XAWL", "XASB", "XASF", "XAAT", "XAWL", "XASW", "XASB", "XASF", "XAAT", "XAWE", "🇦🇹Neu H1", "XASH", "NPA", "NPL", "NOT", "NRH", "NN", "NF", "NBA", "NED", "UE P", "LPLN", "LH", "LW", "BJUE", "BL" ]
+					"pathSuggestion": [ "XEMAT", "XEB", "XFNB", "🇫🇷VLM", "🇫🇷NPG", "XFAVV", "XFM", "XIAQ", "XITOR", "XIMB", "XSBZ", "XSBC", "XSADF", "XSAG", "XSTW", "XSZH", "XSZO", "XSSG", "XSRS", "XSSM", "XSBU", "XAND", "XAFK", "XAB", "MLIR", "MHGZ", "MIMS", "MKP", "MBIH", "MBU", "MKFG", "MGE", "MH", "MGB", "MRO", "MTS", "MFL", "XASB", "XASF", "XAAT", "XAWE", "🇦🇹Neu H1", "XASH", "NPA", "NPL", "NOT", "NRH", "NN", "NF", "NBA", "NED", "UE P", "LPLN", "LH", "LW", "BJUE", "BL" ]
 				},
 				{
 					"stations": [ "BL", "FF", "XFSTG", "XLL", "XBB", "XNAC", "AH", "XDKH", "XVS" ],
@@ -4543,7 +4543,7 @@
 				},
 				{
 					"stations": [ "XFSTG", "XSBE", "XIMB", "XIVP", "XAWW", "XMBK", "XJBC", "XWS", "XQIS" ],
-					"pathSuggestion": [ "XFSTG", "XFMV", "XSB", "XSGRN", "XSBL", "XSBE", "XSSP", "XSVI", "XIR", "XIMB", "XIVP", "XIFF", "XAI",  "🇦🇹Fw Z2", "XAWL", "XASW", "XASB", "XASF", "XAAT", "XAWL", "XASB", "XASF", "XAAT", "XAWE",  "XAWW", "XMBK", "XJSP", "XJBC", "XWS", "XQIS" ]
+					"pathSuggestion": [ "XFSTG", "XFMV", "XSB", "XSOL", "XSZG", "XSLT", "XSBE", "XSSP", "XSVI", "XIR", "XIMB", "XIVP", "XIFF", "XAI", "🇦🇹Fw Z2", "XAWL", "MRO", "MTS", "MFL", "XASB", "XASF", "XAAT", "XAWE", "XAWW", "XMBK", "XJSP", "XJBC", "XWS", "XQIS" ]
 				}
 			],
 			"neededCapacity": [


### PR DESCRIPTION
Es gibt jetzt auch eine Prüfung, dass die pathSuggestions zumindest korrekt Pfade darstellen und die Berechnung sollte auch deutlich robuster sein.

Es gibt aber ein Problem, dass manche österreichische Betriebsstellen Kleinbuchstaben im Code haben, was meine Tools nur z.T. berücksichtigen. Dadurch kann es bei der Prüfung (oder perspektivisch automatischen Korrekturen) teils zu Fehlern kommen, weshalb die Funktion noch nicht im main-Branch ist.