### PR TITLE
Pfadfinderirrfahrten Herzberg und Plaue(n)

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3940,6 +3940,8 @@
 				{"stations": [ "SRO", "MRBI" ]},
 				{"stations": [ "AOL", "HOLD" ]},
 				{"stations": [ "FF", "BFP"   ]},
+				{"stations": [ "HHB", "LHZW" ]},
+				{"stations": [ "UPL", "DP"   ]},
 				{"stations": [ "HBNF", "🇳🇱Brn"]},
 				{"stations": [ "MER", "🇬🇧RDG"]},
 				{"stations": [ "FNSM", "HNRU"]},


### PR DESCRIPTION
Fügt Herzberg (Harz) - Herzberg (Elster) und Plaue (Thür) - Plauen (Vogtland) oberer Bahnhof als Start-Ziel-Kombination für den Pfadfinderauftrag hinzu