### PR TITLE
Add Citylink

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -1321,6 +1321,44 @@
 			]
 		},
 		{
+			"id": 232,
+			"group": 2,
+			"name": "Stadler Citylink D/E",
+			"shortcut": "Citylink",
+			"speed": 100,
+			"weight": 68,
+			"force": 39,
+			"length": 37,
+			"drive": 4,
+			"reliability": 1,
+			"cost": 500000,
+			"operationCosts": 75,
+			"maxConnectedUnits": 2,
+			"equipments": [ "bostrab", "DE", "HU" ],
+			"capacity": [
+				{"name": "passengers", "value": 87}
+			]
+		},
+		{
+			"id": 233,
+			"group": 2,
+			"name": "Stadler Citylink E/E",
+			"shortcut": "Citylink",
+			"speed": 100,
+			"weight": 68,
+			"force": 58,
+			"length": 37,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 500000,
+			"operationCosts": 60,
+			"maxConnectedUnits": 4,
+			"equipments": [ "bostrab", "DE", "GB", "AT" ],
+			"capacity": [
+				{"name": "passengers", "value": 96}
+			]
+		},
+		{
 			"id": 303,
 			"group": 2,
 			"name": "Crusalis Contessa",


### PR DESCRIPTION
Fügt den Citylink in dieselelektrischer und zweisystemelektrischer Variante hinzu.
Soweit ich dafür Daten gefunden habe, orientiert sich D/E an Chemnitz und E/E an Sheffield.
Die Zugkraft ist bei E/E deutlich höher (auch ggü. ET 2010), weil Sheffield sechs statt vier angetriebene Achsen hat, mindestens bei der Chemnitzer E/E-Variante wird das auch so sein, ist also nicht vollkommen ungewöhnlich.

Diskutabel ist die daraus resultierende geringere Kapazität bei D/E wegen der in Chemnitz verbauten Toilette.
Ebenfalls diskutabel ist, ob die D/E-Variante wirklich als Hybrid geführt werden sollte, da diese elektrisch nur unter Straßenbahnspannung (600 bis 750 V DC) und nicht unter Vollbahnspannung fahren kann. Nur auf normale Vollbahnstrecken bezogen könnte man sie also als reine Dieselfahrzeuge behandeln.
(Deshalb erstmal als Draft.)

Die Kosten habe ich aufgrund der Vorteile in Sachen Hybridantrieb, Zugkraft und Länderzulassungen etwas höher als beim ET 2010 angesetzt.