### PR TITLE
Shorten the name of Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch to Llanfairpwll

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -23774,7 +23774,7 @@
 			"proj": 1
 		},
 		{
-			"name": "Llanfairpwll",
+			"name": "Llanfairpwll...",
 			"ril100": "🇬🇧LPG",
 			"group": 2,
 			"x": -1329,

--- a/Station.json
+++ b/Station.json
@@ -23774,7 +23774,7 @@
 			"proj": 1
 		},
 		{
-			"name": "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
+			"name": "Llanfairpwll",
 			"ril100": "🇬🇧LPG",
 			"group": 2,
 			"x": -1329,


### PR DESCRIPTION
Weil es ja doch einige Beschwerden gibt... 🙄

Eigentlich sollte ich dazu auch die West Coast Main Line löschen.....