### PR TITLE
zusätzliche Ausschreibungen für Frankreich und Großbritannien

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5775,6 +5775,43 @@
 				}				
 			],
 			"stopsEverywhere": true
-		}		
+		},
+		{
+			"name": "Frecciarossa von %s nach %s",
+			"descriptions": [
+				"Bringe den Frecciarossa von %s nach %s.",
+				"Bringe diese Hochgeschwindigkeitsleistung durch Norditalien."
+				"Fahre über die SFS von %s nach %s."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "bistroseats" }
+			],
+			"group": 1,
+			"service": 0,
+			"objects": [
+				{
+					"stations": [ "XIT", "XICER", "🇮🇹03202", "XIVNS", "XIVP", "XIBCA", "XIMB", "XITU" ],
+					"pathSuggestion": [ "XIT", "🇮🇹03313", "XICER", "🇮🇹03202", "XIVNS", "XIVP", "XIBCA", "XIMB", "XIR", "XITU" ]
+				}
+			]
+		},
+		{
+			"name": "InterCity von %s nach %s",
+			"descriptions": [
+				"Bringe diesen InterCity von %s nach %s."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"service": 1,
+			"objects": [
+				{
+					"stations": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIVOG", "XIPIV", "XIMB" ],
+					"pathSuggestion": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIVOG", "XIPIV", "XIMB" ]
+				}
+			]
+		},		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5681,9 +5681,6 @@
 					"stations": [ "XFPO", "🇫🇷VCR", "🇫🇷CHH", "XFLM" ]
 				},
 				{
-					"stations": [ "XFLM", "XFLAL" ]
-				},
-				{
 					"stations": [ "XFLM", "XFASL", "XFNA" ]
 				},
 				{
@@ -5718,9 +5715,6 @@
 				},
 				{
 					"stations": [ "XFLPD", "XFAE", "XFCZ", "XFAI", "XFMOD" ]
-				},
-				{
-					"stations": [ "XFB", "XFBTV" ]
 				},
 				{
 					"stations": [ "XFPO", "XFMEL", "🇫🇷SES", "🇫🇷SIF", "🇫🇷PAI", "XFD" ]
@@ -5760,6 +5754,27 @@
 				}				
 			],
 			"stopsEverywhere": true
-		},		
+		},
+		{
+			"name": "TER von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre diesen TER von %s nach %s.",
+				"Fahre als Zubringer von und zum TGV-Bahnhof von %s nach %s."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"objects": [
+				{
+					"stations": [ "XFLM", "XFLAL" ]
+				},
+				{
+					"stations": [ "XFB", "XFBTV" ]
+				}				
+			],
+			"stopsEverywhere": true
+		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5539,7 +5539,7 @@
 		},
 		{
 			"name": "Regionalzug von %s nach %s",
-			"service": 3,
+			"service": 2,
 			"descriptions": [
 				"Bringe diesen Regionalzug von %s nach %s.",
 				"Fahre ohne Verspätungen durch Großbritannien."
@@ -5587,6 +5587,74 @@
 				}					
 			],
 			"stopsEverywhere": true
+		},
+		{
+			"name": "TER-GV von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre pünktlich auf der Schnellfahrstrecke von %s nach %s.",
+				"Binde die an der französischen Nordküste liegenden Städte an Lille an."
+			],
+			"stations": [ "XFLIE", "XFFE", "🇫🇷BEM", "🇫🇷ETA", "🇫🇷RDF" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "Transilien von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe diesen Vorortzug von %s nach %s.",
+				"Verbinde Paris mit ihren Vororten."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"objects": [
+				{
+					"stations": [ "XFPO", "XFCR" ]
+				},
+				{
+					"stations": [ "XFPO", "🇫🇷VCR", "🇫🇷RBT" ]
+				},
+				{
+					"stations": [ "XFPO", "XFMEL" ]
+				},
+				{
+					"stations": [ "XFPO", "XFMEA", "🇫🇷NAA", "XFCT" ]
+				}				
+			],
+			"stopsEverywhere": true
+		},
+		{
+			"name": "RER A von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe diesen Vorortzug von %s nach %s.",
+				"Diese Linie dient hauptsächlich dem Pendelverkehr sowie Besuchen des nahegelegenen Freizeitparks."
+			],
+			"stations": [ "XFPO", "XFVAR", "XFMVC" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "RER C von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe diesen Vorortzug von %s nach %s."
+			],
+			"stations": [ "XFPO", "XFETP" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5775,43 +5775,6 @@
 				}				
 			],
 			"stopsEverywhere": true
-		},
-		{
-			"name": "Frecciarossa von %s nach %s",
-			"descriptions": [
-				"Bringe den Frecciarossa von %s nach %s.",
-				"Bringe diese Hochgeschwindigkeitsleistung durch Norditalien."
-				"Fahre über die SFS von %s nach %s."
-			],
-			"neededCapacity": [
-				{ "name": "passengers" },
-				{ "name": "bistroseats" }
-			],
-			"group": 1,
-			"service": 0,
-			"objects": [
-				{
-					"stations": [ "XIT", "XICER", "🇮🇹03202", "XIVNS", "XIVP", "XIBCA", "XIMB", "XITU" ],
-					"pathSuggestion": [ "XIT", "🇮🇹03313", "XICER", "🇮🇹03202", "XIVNS", "XIVP", "XIBCA", "XIMB", "XIR", "XITU" ]
-				}
-			]
-		},
-		{
-			"name": "InterCity von %s nach %s",
-			"descriptions": [
-				"Bringe diesen InterCity von %s nach %s."
-			],
-			"neededCapacity": [
-				{ "name": "passengers" }
-			],
-			"group": 1,
-			"service": 1,
-			"objects": [
-				{
-					"stations": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIVOG", "XIPVI", "XIMB" ],
-					"pathSuggestion": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIVOG", "XIPVI", "XIMB" ]
-				}
-			]
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5699,7 +5699,7 @@
 					"stations": [ "XFBJ", "🇫🇷AGN" ]
 				},
 				{
-					"stations": [ "AGN", "XFMBN", "XFTM" ]
+					"stations": [ "🇫🇷AGN", "XFMBN", "XFTM" ]
 				},
 				{
 					"stations": [ "XFTM", "XFCN", "XFNB" ]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5808,10 +5808,10 @@
 			"service": 1,
 			"objects": [
 				{
-					"stations": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIVOG", "XIPIV", "XIMB" ],
-					"pathSuggestion": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIVOG", "XIPIV", "XIMB" ]
+					"stations": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIVOG", "XIPVI", "XIMB" ],
+					"pathSuggestion": [ "XIVT", "XITG", "XIIO", "XIAO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIVOG", "XIPVI", "XIMB" ]
 				}
 			]
-		},		
+		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5655,6 +5655,111 @@
 				{ "name": "passengers" }
 			],
 			"group": 1
-		}		
+		},
+		{
+			"name": "TER von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Bringe diesen TER von %s nach %s.",
+				"Fahre ohne Verspätungen durch Frankreich."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"objects": [
+				{
+					"stations": [ "XFLIE", "XFHZ", "XFDK" ]
+				},
+				{
+					"stations": [ "XFFE", "🇫🇷BEM", "🇫🇷RDF", "🇫🇷AMS" ]
+				},
+				{
+					"stations": [ "XFLIE", "XFAS", "🇫🇷AMS", "XFCR", "XFPO" ]
+				},
+				{
+					"stations": [ "XFPO", "🇫🇷VCR", "🇫🇷CHH", "XFLM" ]
+				},
+				{
+					"stations": [ "XFLM", "XFLAL" ]
+				},
+				{
+					"stations": [ "XFLM", "XFASL", "XFNA" ]
+				},
+				{
+					"stations": [ "XFNA", "🇫🇷SNA" ]
+				},
+				{
+					"stations": [ "XFLM", "🇫🇷SLG", "XFLAL", "XFVTE", "XFR" ]
+				},
+				{
+					"stations": [ "XFNA", "XFASL", "XFSUD", "🇫🇷TO" ]
+				},
+				{
+					"stations": [ "🇫🇷TO", "XFOL", "XFPO" ]
+				},
+				{
+					"stations": [ "XFBJ", "🇫🇷AGN" ]
+				},
+				{
+					"stations": [ "AGN", "XFMBN", "XFTM" ]
+				},
+				{
+					"stations": [ "XFTM", "XFCN", "XFNB" ]
+				},
+				{
+					"stations": [ "XFPE", "XFNB", "XFBZ", "XFSE", "🇫🇷FRN", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFARL", "XFMI", "XFM" ]
+				},
+				{
+					"stations": [ "XFM", "XFMI", "XFARL", "XFAVV" ]
+				},
+				{
+					"stations": [ "XFAVV", "XFOR", "XFMN", "XFVCV", "XFVI", "XFLPD" ]
+				},
+				{
+					"stations": [ "XFLPD", "XFAE", "XFCZ", "XFAI", "XFMOD" ]
+				},
+				{
+					"stations": [ "XFB", "XFBTV" ]
+				},
+				{
+					"stations": [ "XFPO", "XFMEL", "🇫🇷SES", "🇫🇷SIF", "🇫🇷PAI", "XFD" ]
+				},
+				{
+					"stations": [ "XFD", "🇫🇷GLS", "XFDO" ]
+				},
+				{
+					"stations": [ "XFDO", "XFMOU", "🇨🇭VAL" ]
+				},
+				{
+					"stations": [ "XFPO", "XFMEA", "🇫🇷NAA", "XFE", "XFCM", "XFBD" ]
+				},
+				{
+					"stations": [ "XFSHT", "XFCM" ]
+				},
+				{
+					"stations": [ "XFSTG", "RAP", "RO" ]
+				},
+				{
+					"stations": [ "XFCM", "XFBD", "XFLE", "XFTU", "XFFD", "XFN" ]
+				},
+				{
+					"stations": [ "SSH", "XFMZV" ]
+				},
+				{
+					"stations": [ "XFMZV", "XFPS", "XFO", "XFLE", "XFBD" ]
+				},
+				{
+					"stations": [ "XFSTG", "XFSL", "XFC", "XFMV", "XSB" ]
+				},
+				{
+					"stations": [ "XFMV", "RML" ]
+				},
+				{
+					"stations": [ "XFCA", "XFNC", "XFMC", "XIVT" ]
+				}				
+			],
+			"stopsEverywhere": true
+		},		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5486,6 +5486,107 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
-		}
+		},
+		{
+			"name": "Caledonian Sleeper von %s nach %s",
+			"descriptions": [
+				"Fahre entlang der West Coast Main Line von %s nach %s.",
+				"Fahrgäste von und nach Nordschottland müssen in einen Regionalzug umsteigen."
+			],
+			"objects": [
+				{
+					"stations": [ "XKLP", "🇬🇧CAR", "🇬🇧MTH", "🇬🇧GLC" ],
+					"pathSuggestion": [ "XKLP", "🇬🇧SOT", "🇬🇧CAR", "🇬🇧CRSTRSS", "🇬🇧GLC" ]
+				},
+				{
+					"stations": [ "XKLP", "🇬🇧CAR", "🇬🇧EDB" ],
+					"pathSuggestion": [ "XKLP", "🇬🇧SOT", "🇬🇧CAR", "🇬🇧CRSTRSS", "🇬🇧EDB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "beds" },
+				{ "name": "bistroseats" }				
+			],
+			"group": 1,
+			"service": 1
+		},
+		{
+			"group": 1,
+			"name": "Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre auf der HS1 von %s nach %s."
+			],
+			"stations": [ "XKLP", "XKSF", "XKEI", "XKAI" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"name": "Elizabeth Line von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre pünktlich von %s nach %s.",
+				"Aus technischen Gründen ist in Paddington ein Umstieg in einen stammstreckentauglichen Zug erforderlich."
+			],
+			"stations": [ "XKLP", "🇬🇧RDG" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "Regionalzug von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Bringe diesen Regionalzug von %s nach %s.",
+				"Fahre ohne Verspätungen durch Großbritannien."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"objects": [
+				{
+					"stations": [ "XKLP", "🇬🇧RDG", "🇬🇧DID" ]
+				},
+				{
+					"stations": [ "🇬🇧DID", "🇬🇧SWI", "🇬🇧BTH", "🇬🇧BRI" ]
+				},
+				{
+					"stations": [ "XKLP", "🇬🇧BLY", "🇬🇧NMP", "XKRU", "🇬🇧BHI", "🇬🇧BHM" ]
+				},
+				{
+					"stations": [ "🇬🇧LIV", "🇬🇧RUN", "XKCR", "🇬🇧SOT" ]
+				},
+				{
+					"stations": [ "🇬🇧HHD", "🇬🇧AGL", "🇬🇧PRT", "🇬🇧CTR", "XKCR" ]
+				},
+				{
+					"stations": [ "🇬🇧SOT", "🇬🇧MAN" ]
+				},
+				{
+					"stations": [ "🇬🇧MAN", "🇬🇧BON", "🇬🇧PNR", "🇬🇧MTH", "🇬🇧GLC" ]
+				},
+				{
+					"stations": [ "XKLP", "🇬🇧PBO" ]
+				},
+				{
+					"stations": [ "🇬🇧PBO", "🇬🇧DON", "🇬🇧YRK" ]
+				},
+				{
+					"stations": [ "🇬🇧DON", "🇬🇧YRK", "🇬🇧DAR", "🇬🇧NCL" ]
+				},
+				{
+					"stations": [ "🇬🇧NCL", "🇬🇧EDB" ]
+				},
+				{
+					"stations": [ "🇬🇧EDB", "🇬🇧MTH", "🇬🇧GLC" ]
+				}					
+			],
+			"stopsEverywhere": true
+		}		
 	]
 }


### PR DESCRIPTION
Hinzufügung zusätzlicher Ausschreibungen für Frankreich und Großbritannien. Es werden hauptsächlich TER/Regionalzüge hinzugefügt, allerdings sind auch Vorortzüge sowie Nachtzugverbindungen vorhanden.