### PR TITLE
Use realistic numbers for IC2000 dining car

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5076,7 +5076,7 @@
 			"exchangeTime": 120,
 			"capacity": [
 				{"name": "bistroseats", "value": 16},
-				{"name": "passengers", "value": 40}
+				{"name": "passengers", "value": 60}
 			]
 		},
 		{
@@ -5093,7 +5093,8 @@
 			"cost": 260000,
 			"exchangeTime": 120,
 			"capacity": [
-				{"name": "bistroseats", "value": 26}
+				{"name": "bistroseats", "value": 32},
+				{"name": "passengers", "value": 13}
 			]
 		},
 		{


### PR DESCRIPTION
- Das Restaurant hat mehr Stizplätze und auch normale Plätze, wie es in https://youtu.be/IUnBNJbBjq4?t=271 zu sehen ist. (Leider kann ich die Plätze oben nicht ganz sehen. Aus anderen Fotos wird es aber ersichtlich, dass es wohl um die 24 Plätze sind)
- Das Bistro hat jetzt fast die Hälfte der normalen Plätze eines Wagens, was denke ich Sinn ergibt. Bei den Bistroplätzen bin ich mir da allerdings nicht ganz sicher.

Leider gibt es zu den Wagen allgemein eher wenig Informationen/Bilder...