### PR TITLE
zusätzliche Ausschreibungen

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6432,7 +6432,7 @@
 		},
 		{
 			"name": "Intercity von %s nach %s",
-			"service": 3,
+			"service": 1,
 			"descriptions": [
 				"Fahre von %s nach %s.",
 				"Verbinde Belgien und Luxemburg."
@@ -6447,6 +6447,47 @@
 				{ "name": "passengers" }
 			],
 			"group": 1
-		}			
+		},
+		{
+			"group": 1,
+			"name": "Regio von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre im Auftrag der Železnice Srbije diesen Regionalzug zwischen %s und %s.",
+				"Übernehme die Verbindung zwischen %s und %s und halte dabei an allen Stationen.",
+				"Fahre mit diesen Regionalzug durch Serbien."
+			],
+			"objects": [
+				{
+					"stations": [ "XJPR", "XJNI" ]
+				}
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Regio von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre im Auftrag der Makedonski železnici diesen Regionalzug zwischen %s und %s.",
+				"Übernehme die Verbindung zwischen %s und %s und halte dabei an allen Stationen.",
+				"Fahre mit diesen Regionalzug durch Nordmazedonien."
+			],
+			"objects": [
+				{
+					"stations": [ "ZAS", "XJTA" ]
+				},
+				{
+					"stations": [ "ZAS", "🇲🇰61708" ]
+				}				
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6541,6 +6541,25 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
+		},
+		{
+			"group": 1,
+			"name": "Személyvonat von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre im Auftrag der MÁV diesen Regionalzug zwischen %s und %s.",
+				"Übernehme die Verbindung zwischen %s und %s und halte dabei an allen Stationen.",
+				"Fahre mit diesen Regionalzug durch Ungarn."
+			],
+			"objects": [
+				{
+					"stations": [ "XMBK", "XMSN", "XMBS" ]
+				}
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6707,7 +6707,7 @@
 			"name": "EuroNight von %s nach %s",
 			"service": 1,
 			"descriptions": [
-				"Bringe die schlafenden Fahrgäste von %s nach %s."
+				"Bringe die schlafenden Fahrgäste von %s nach %s.",
 				"Verbinde Österreich, Ungarn und Rumänien miteinander."
 			],
 			"stations": [ "XUBN", "🇷🇴30691", "XMBS", "XMSN", "XMBK", "XMG", "XMHY", "XAWW" ],
@@ -6716,6 +6716,47 @@
 				{ "name": "beds" },
 				{ "name": "bistroseats" }				
 			]
-		}		
+		},
+		{
+			"group": 1,
+			"name": "Intercity von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre diesen Intercity von %s nach %s.",
+				"Fahre durch Rumänien."
+			],
+			"stations": [ "XUBN", "XUPV", "🇷🇴30691", "XUM", "XUAI", "XUD", "XUA" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "bistroseats" }				
+			]
+		},
+		{
+			"group": 1,
+			"name": "Intercity von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre diesen Intercity von %s nach %s.",
+				"Fahre durch den Osten Ungarns."
+			],
+			"stations": [ "XMBK", "XMSN", "XMBS" ],
+			"neededCapacity": [
+				{ "name": "passengers" }				
+			]
+		},
+		{
+			"group": 1,
+			"name": "Intercity von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre diesen internationalen Intercity von %s nach %s.",
+				"Verbinde Ungarn und Rumänien miteinander."
+			],
+			"stations": [ "XMBK", "XMSN", "XMBS", "XUCU", "XUA", "XUBN" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "bistroseats" }				
+			]
+		}			
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6652,7 +6652,7 @@
 			"name": "Schnellzug von %s nach %s",
 			"service": 1,
 			"descriptions": [
-				"Bringe diesen internationale Schnellzug von %s nach %s."
+				"Bringe diesen internationalen Schnellzug von %s nach %s."
 			],
 			"objects": [
 				{
@@ -6665,6 +6665,56 @@
 			"stopsEverywhere": false,
 			"neededCapacity": [
 				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe diesen Schnellzug von %s nach %s.",
+				"Fahre durch Bulgarien."
+			],
+			"objects": [
+				{
+					"stations": [ "XWS", "XWPL", "XWR" ]
+				},
+				{
+					"stations": [ "XWS", "XWPR", "XWBL" ]
+				}				
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Nacht-Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe die schlafenden Fahrgäste von %s nach %s."
+				"Verbinde Griechenland, Bulgarien und Rumänien miteinander."
+			],
+			"stations": [ "XUBN", "XUV", "XUGN", "XWR", "🇧🇬24000", "XWS", "XWPR", "XWRA", "XWDU", "XWBL", "XWSN", "XGT" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "beds" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "EuroNight von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe die schlafenden Fahrgäste von %s nach %s."
+				"Verbinde Österreich, Ungarn und Rumänien miteinander."
+			],
+			"stations": [ "XUBN", "🇷🇴30691", "XMBS", "XMSN", "XMBK", "XMG", "XMHY", "XAWW" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "beds" },
+				{ "name": "bistroseats" }				
 			]
 		}		
 	]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6693,7 +6693,7 @@
 			"name": "Nacht-Schnellzug von %s nach %s",
 			"service": 1,
 			"descriptions": [
-				"Bringe die schlafenden Fahrgäste von %s nach %s."
+				"Bringe die schlafenden Fahrgäste von %s nach %s.",
 				"Verbinde Griechenland, Bulgarien und Rumänien miteinander."
 			],
 			"stations": [ "XUBN", "XUV", "XUGN", "XWR", "🇧🇬24000", "XWS", "XWPR", "XWRA", "XWDU", "XWBL", "XWSN", "XGT" ],

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6518,6 +6518,29 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
+		},
+		{
+			"group": 1,
+			"name": "Lokalzug von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre durch Bulgarien und halte dabei an allen Stationen."
+			],
+			"objects": [
+				{
+			"stations": [ "XWBL", "XWS" ]
+				},
+				{
+			"stations": [ "XWBL", "XWSN" ]
+				},
+				{
+			"stations": [ "XWR", "🇧🇬14000" ]
+				}				
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6604,6 +6604,35 @@
 				{ "name": "passengers" }
 			],
 			"group": 1
-		}			
+		},
+		{
+			"group": 1,
+			"name": "Nacht-Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe die Fahrgäste von %s nach %s.",
+				"Verbinde Serbien, Nordmazedonien und Griechenland miteinander."
+			],
+			"stations": [ "XJBC", "XJNI", "XJPR", "XJTA", "ZAS", "XGI", "XGT" ],
+			"pathSuggestion": [ "XJBC", "XJNI", "XJPR", "XJTA", "ZAS", "XGI", "XGT" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "beds" }
+			]
+		},
+		{
+			"name": "Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Fahre durch den Nordmazedonien."
+			],
+			"stations": [ "XAKU", "ZAS", "🇲🇰61601" ],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6421,7 +6421,7 @@
 			],
 			"objects": [
 				{
-					"stations": [ "XNAC", "🇳🇱ZVT" ]
+					"stations": [ "XNAC", "🇳🇱Zvt" ]
 				}
 			],
 			"stopsEverywhere": true,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6633,6 +6633,39 @@
 				{ "name": "passengers" }
 			],
 			"group": 1
+		},
+		{
+			"group": 1,
+			"name": "Bosphorus Express von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe die schlafenden Fahrgäste von %s nach %s."
+			],
+			"stations": [ "XQIS", "XQHA", "XQCK", "XQED", "🇧🇬14000", "XWR", "XUBN" ],
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "beds" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Schnellzug von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Bringe diesen internationale Schnellzug von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "XWS", "XWPR", "XWRA", "XWDU", "XWBL", "XGT" ]
+				},
+				{
+					"stations": [ "XWS", "XWPL", "XWR", "XUBN" ]
+				}				
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6411,6 +6411,42 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
-		}
+		},
+		{
+			"name": "Stoptrein von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Fahre durch die Niederlande."
+			],
+			"objects": [
+				{
+					"stations": [ "XNAC", "🇳🇱ZVT" ]
+				}
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "Intercity von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Verbinde Belgien und Luxemburg."
+			],
+			"objects": [
+				{
+					"stations": [ "XBB", "XBOT", "XBNA", "XBAR", "XLL" ]
+				}
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		}			
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6488,6 +6488,36 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
+		},
+		{
+			"group": 1,
+			"name": "Regional von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Übernehme die Verbindung zwischen %s und %s und halte dabei an allen Stationen.",
+				"Fahre mit diesen Regionalzug durch Griechenland."
+			],
+			"objects": [
+				{
+					"stations": [ "XGA", "XGLV", "XGL" ]
+				},
+				{
+					"stations": [ "XGL", "XGT" ]
+				},
+				{
+					"stations": [ "XGPM", "XGT" ]
+				},
+				{
+					"stations": [ "XGPM", "XGAX" ]
+				},
+				{
+					"stations": [ "XGD", "XGAX" ]
+				}				
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
 		}		
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6560,6 +6560,50 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
-		}		
+		},
+		{
+			"name": "Intercity Express von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Verbinde die beiden größten Städte Griechenlands miteinander."
+			],
+			"stations": [ "XGA", "XGL", "XGT" ],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "bistroseats" }
+			],
+			"group": 1
+		},
+		{
+			"name": "Intercity von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Fahre durch Griechenland."
+			],
+			"stations": [ "XGA", "XGIN", "XGLV", "XGPA", "XGL", "XGK", "XGT" ],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" },
+				{ "name": "bistroseats" }
+			],
+			"group": 1
+		},
+		{
+			"name": "Express von %s nach %s",
+			"service": 1,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Fahre durch den Norden Griechenlands."
+			],
+			"stations": [ "XGT", "XGKK", "XGR", "XGPM", "XGDM", "XGX", "XGAX" ],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		}			
 	]
 }


### PR DESCRIPTION
Hinzufügung internationaler Schnellzugausschreibungen für Griechenland, Bulgarien, Rumänien und Nordmazedonien, zusätzliche Ausschreibungen für Ausschreibungen innerhalb Griechenlands, Bulgariens, Rumäniens, Serbiens, der Niederlande, Luxemburg sowie Ungarns, um die dort neu hinzugefügten Strecken nutzen zu können.