### PR TITLE
TEE jobs part 5

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -4958,6 +4958,16 @@
 				},
 				{
 					"descriptions": [
+						"Fahre den TEE Iris von %s bis %s"
+					],
+					"stations": [ "XBB", "XBNA", "XBAR", "XLL", "XFTHV", "XFMZV", "XFSTG", "XFC", "XFMV", "XSB", "XSZH" ],
+					"pathSuggestion": [ "XBB", "XBOT", "XBNA", "XBAR", "XLL", "XFTHV", "XFMZV",
+						 "XFPS", "XFFD", "XFN", "XFLU", "XFRD", "XFSV", "XFVH",
+						 "XFSTG", "XFSL", "XFC", "XFMV", "XSB", "XSOL", "XSKS", "XSZH"
+					]
+				},
+				{
+					"descriptions": [
 						"Fahre den TEE Prinz Eugen von %s bis %s"
 					],
 					"stations": [ "HB", "HH", "HG", "FB", "NWH", "NN", "NRH", "NPA", "XAWE", "XAL", "XAWW" ],

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -4945,6 +4945,19 @@
 				},
 				{
 					"descriptions": [
+						"Fahre den TEE Saphir von %s bis %s"
+					],
+					"stations": [ "EDO", "EBO", "EE", "EDG", "KD", "KK", "KA",
+						"XBHE",
+						"XBLIG", "XBB", "XBGP", "XBBR", "XBO"
+					],
+					"pathSuggestion": [ "EDO", "EBO", "EE", "EDG", "KD", "KK", "KDN" , "KA",
+						"XBHE",
+						"XBLIG", "XBB", "XBAAS", "XBGP", "XBBR", "XBO"
+					]
+				},
+				{
+					"descriptions": [
 						"Fahre den TEE Prinz Eugen von %s bis %s"
 					],
 					"stations": [ "HB", "HH", "HG", "FB", "NWH", "NN", "NRH", "NPA", "XAWE", "XAL", "XAWW" ],


### PR DESCRIPTION
part of #389 

- TEE Saphir Ostende-Brügge-Lüttich-Aachen-Köln-Dortmund ([preview](https://traincompany.de/index.php?module=Game_Map&options[stations]=EDO-EBO-EE-EDG-KD-KK-KA-XBHE-XBLIG-XBB-XBAAS-XBGP-XBBR-XBO&options[pathUnit]=EDO-EBO-EE-EDG-KD-KK-KDN-KA-XBHE-XBLIG-XBB-XBAAS-XBGP-XBBR-XBO))
- TEE Iris Bruxelles-Namur-Luxembourg-Metz-Basel-Zürich ([preview](https://traincompany.de/index.php?module=Game_Map&options[stations]=XBB-XBOT-XBNA-XBAR-XLL-XFTHV-XFMZV-XFPS-XFFD-XFN-XFLU-XFRD-XFSV-XFVH-XFSTG-XFSL-XFC-XFMV-XSB-XSOL-XSKS-XSZH&options[pathUnit]=XBB-XBOT-XBNA-XBAR-XLL-XFTHV-XFMZV-XFPS-XFFD-XFN-XFLU-XFRD-XFSV-XFVH-XFSTG-XFSL-XFC-XFMV-XSB-XSOL-XSKS-XSZH))