### PR TITLE
kleineren Fehler korrigiert

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -6637,7 +6637,7 @@
 				"Fahre von %s nach %s.",
 				"Fahre durch den Nordmazedonien."
 			],
-			"stations": [ "XAKU", "ZAS", "🇲🇰61601" ],
+			"stations": [ "ZAKU", "ZAS", "🇲🇰61601" ],
 			"stopsEverywhere": false,
 			"neededCapacity": [
 				{ "name": "passengers" }


### PR DESCRIPTION
Der nördliche Endpunkt für den innermazedonischen Schnellzug sollte jetzt auch in Nordmazedonien liegen.