### PR TITLE
add equipment for ČD 810, also add shortcut

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -2984,7 +2984,8 @@
 		{
 			"id": 54810,
 			"group": 2,
-			"name": "ČD/ZSSK-Baureihe 810",
+			"name": "ČD/ZSSK-Baureihe 810 (ČSD M152)",
+			"shortcut": "ČD 810",
 			"speed": 80,
 			"weight": 20,
 			"force": 29,
@@ -2994,7 +2995,7 @@
 			"cost": 180000,
 			"maxConnectedUnits": 4,
 			"operationCosts": 30,
-			"equipments": ["CZ", "SK", "HU"],
+			"equipments": ["CZ", "SK", "HU", "DE", "AT", "PL"],
 			"exchangeTime": 35,
 			"capacity": [
 				{"name": "passengers", "value": 55}


### PR DESCRIPTION
kam/kommt auch im dt/cz, cz/pl und cz/at Nebenbahn-Grenzverkehr zum Einsatz.
(z.B. Johanngeorgenstadt, Bad Schandau, Zagórze, Retz)