### PR TITLE
Korrektur Kapazität RA2

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -3971,7 +3971,7 @@
 			"equipments": [ "UA", "RU", "LV", "1520mm" ],
 			"exchangeTime": 60,
 			"capacity": [
-				{ "name": "passengers", "value": 600 }
+				{ "name": "passengers", "value": 222 }
 			]
 		},
 		{


### PR DESCRIPTION
Verringerung der Kapazität der RA2 von 600 Passagieren (mit Stehplätzen) zu 222 Passagiere (nur Sitzplätze).