### PR TITLE
remove superflous inheriting object that missed "stations"

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2402,8 +2402,7 @@
 			"objects": [
 				{
 					"stations": [ "DH", "DAF", "DBW", "DNKW", "DWT", "DEB", "DEIB", "DZ" ]
-				},
-				{}
+				}
 			],
 			"stopsEverywhere": true,
 			"neededCapacity": [


### PR DESCRIPTION
which probably causes the bug reported in
https://twitter.com/Chill_LP/status/1560617107812978688

in combination with object reuse or caching in task generation randomizer