### PR TITLE
Add DE, CH, ES to Avelia Horizon, increase price by 1M

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -204,9 +204,9 @@
 			"length": 200,
 			"drive": 1,
 			"reliability": 1.0,
-			"cost": 6500000,
+			"cost": 7500000,
 			"operationCosts": 70,
-			"equipments": [ "ETCS", "FR", "TVM", "BE", "IT", "LU" ],
+			"equipments": [ "ETCS", "FR", "TVM", "BE", "IT", "LU", "DE", "CH", "ES" ],
 			"maxConnectedUnits": 2,
 			"exchangeTime": 150,
 			"capacity": [


### PR DESCRIPTION
Ich bin mir nicht ganz sicher, ob das so angemessen ist.
Zum einen werden die Züge damit doch sehr overpowered, andererseits weiß ich nicht, ob der Preis passt...