### PR TITLE
Korrektur 1520mm-Autotransportwagen

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -7907,6 +7907,7 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 110000,
+			"equipments": ["1520mm"],				
 			"capacity": [
 				{"name": "cars", "value": 8}
 			]


### PR DESCRIPTION
Nachrüstung des 1520mm-Autotransportwagens, damit es auch wirklich für 1520mm geeignet ist.