### PR TITLE
Removed some Vehicles from ICE-L and added 248

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -9288,7 +9288,7 @@
 			"reliability": 1,
 			"cost": 1800000,
 			"maxConnectedUnits": 1,
-			"compatibleWith": [ 251, 245, 5, 28, 26, 193, 15, 30, 29, 6, 102, 2026, 2159 ],
+			"compatibleWith": [ 251, 245, 193, 15, 102, 2026, 248 ],
 			"exchangeTime": 60,
 			"equivalentTo": 17,
 			"capacity": [


### PR DESCRIPTION
Removed 218, F140, 247, F140 AC 3, EuroDual and two more and added Vectron Dualmode for Exchange as Proposed by DBFV