### PR TITLE
Jobs nossen freiberg holzhau

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -10190,9 +10190,49 @@
 				},
 				{
 					"start": "UPL",
+					"end": "UASD",
+					"length": 6,
+					"maxSpeed": 100,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "UASD",
+					"end": "UA",
+					"length": 1,
+					"maxSpeed": 100,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "UA",
+					"end": "UHSN",
+					"length": 4,
+					"maxSpeed": 120,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "UHSN",
+					"end": "USUE",
+					"length": 2,
+					"maxSpeed": 120,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "USUE",
+					"end": "UND",
+					"name": "Thüringer Bahn",
+					"length": 3,
+					"maxSpeed": 160,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "UND",
 					"end": "UE P",
-					"length": 31,
-					"maxSpeed": 100
+					"name": "Thüringer Bahn",
+					"electrified": true,
+					"group": 2,
+					"length": 12,
+					"maxSpeed": 230,
+					"twistingFactor": 0.21
 				}
 			]
 		},
@@ -40331,7 +40371,7 @@
 		},
 		{
 			"name": "Neißetalbahn",
-			"electrified": false,			
+			"electrified": false,
 			"maxSpeed": 100,
 			"group": 1,
 			"objects": [
@@ -40341,7 +40381,9 @@
 					"length": 7,
 					"maxSpeed": 60,
 					"twistingFactor": 0.14,
-					"neededEquipments": [ "DE" ]
+					"neededEquipments": [
+						"DE"
+					]
 				},
 				{
 					"start": "DHE",
@@ -40370,14 +40412,18 @@
 					"end": "DGWH",
 					"length": 7,
 					"twistingFactor": 0.16,
-					"neededEquipments": [ "DE" ]
+					"neededEquipments": [
+						"DE"
+					]
 				},
 				{
 					"start": "DGWH",
 					"end": "DG",
 					"length": 2,
 					"twistingFactor": 0.3,
-					"neededEquipments": [ "DE" ]
+					"neededEquipments": [
+						"DE"
+					]
 				}
 			]
 		},

--- a/Path.json
+++ b/Path.json
@@ -9362,9 +9362,24 @@
 				},
 				{
 					"start": "UWA",
+					"end": "UND",
+					"length": 5,
+					"maxSpeed": 160,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "UND",
+					"end": "UEBI",
+					"length": 7,
+					"maxSpeed": 230,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "UEBI",
 					"end": "UE P",
-					"length": 18,
-					"maxSpeed": 160
+					"length": 6,
+					"maxSpeed": 150,
+					"twistingFactor": 0.15
 				},
 				{
 					"start": "UE P",
@@ -10223,16 +10238,6 @@
 					"length": 3,
 					"maxSpeed": 160,
 					"twistingFactor": 0.14
-				},
-				{
-					"start": "UND",
-					"end": "UE P",
-					"name": "Thüringer Bahn",
-					"electrified": true,
-					"group": 2,
-					"length": 12,
-					"maxSpeed": 230,
-					"twistingFactor": 0.21
 				}
 			]
 		},

--- a/Station.json
+++ b/Station.json
@@ -16656,6 +16656,16 @@
 			"platformLength": 211,
 			"platforms": 4,
 			"proj": 3
+		},		
+		{
+			"name": "Erfurt-Bischleben",
+			"ril100": "UEBI",
+			"group": 5,
+			"x": 610,
+			"y": 137,
+			"platformLength": 240,
+			"platforms": 3,
+			"proj": 3
 		},
 		{
 			"group": 0,

--- a/Station.json
+++ b/Station.json
@@ -16656,7 +16656,7 @@
 			"platformLength": 211,
 			"platforms": 4,
 			"proj": 3
-		},		
+		},
 		{
 			"name": "Erfurt-Bischleben",
 			"ril100": "UEBI",

--- a/Station.json
+++ b/Station.json
@@ -16608,11 +16608,61 @@
 			"proj": 3
 		},
 		{
+			"name": "Arnstadt Süd",
+			"ril100": "UASD",
+			"group": 5,
+			"x": 606,
+			"y": 154,
+			"platformLength": 140,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Arnstadt Hbf",
+			"ril100": "UA",
+			"group": 2,
+			"x": 605,
+			"y": 152,
+			"platformLength": 226,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Haarhausen",
+			"ril100": "UHSN",
+			"group": 5,
+			"x": 599,
+			"y": 148,
+			"platformLength": 140,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Sülzenbrücken",
+			"ril100": "USUE",
+			"group": 5,
+			"x": 598,
+			"y": 145,
+			"platformLength": 140,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Neudietendorf",
+			"ril100": "UND",
+			"group": 2,
+			"x": 600,
+			"y": 140,
+			"platformLength": 211,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
 			"group": 0,
 			"name": "Erfurt Hbf",
 			"ril100": "UE P",
-			"x": 616,
-			"y": 130,
+			"x": 617,
+			"y": 131,
 			"platformLength": 420,
 			"platforms": 10,
 			"proj": 3
@@ -23247,8 +23297,8 @@
 			"group": 2,
 			"name": "Plaue (Thür)",
 			"ril100": "UPL",
-			"x": 599,
-			"y": 162,
+			"x": 600,
+			"y": 163,
 			"platformLength": 190,
 			"platforms": 3,
 			"proj": 3

--- a/Station.json
+++ b/Station.json
@@ -56055,7 +56055,7 @@
 		{
 			"name": "Holzhau Skilift",
 			"ril100": "DHUS",
-			"group": 2,
+			"group": 5,
 			"x": 961,
 			"y": 170,
 			"platformLength": 50,
@@ -56065,7 +56065,7 @@
 		{
 			"name": "Holzhau",
 			"ril100": "DHU",
-			"group": 5,
+			"group": 2,
 			"x": 963,
 			"y": 170,
 			"platformLength": 42,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3272,8 +3272,8 @@
 			"objects": [
 				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHU"] },
 				{ 
-					"stations": [ "DNO", "DDE", "LL", "UNM", "UE P", "UA" ],
-					"pathSuggestion": [ "DNO", "DDE", "LBEU", "LBOR", "LL", "UNM", "UGH", "UWN", "UE P", "UA" ]
+					"stations": [ "DNO", "DDE", "LL", "UNM", "UWM", "UE P", "UA" ],
+					"pathSuggestion": [ "DNO", "DDE", "LBEU", "LBOR", "LL", "UNM", "UGH", "UWM", "UE P", "UND", "UA" ]
 				}
 			],
 			"stopsEverywhere": false,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3283,6 +3283,20 @@
 		},
 		{
 			"group": 1,
+			"name": "Freiberger Eisenbahn von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den RB 83 der Freiberger Eisenbahn von %s nach %s.",
+				"Auch das Erzgebirge ist bei Urlaubern beliebt."
+			],
+			"stations": [ "DFR", "DMUL", "DHU"],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"service": 2,
 			"descriptions": [
 				"Fahre auf deutscher und tschechischer Seite durch Vogtland und Erzgebirge von %s nach %s.",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3261,6 +3261,23 @@
 			]
 		},
 		{
+			"group": 0,
+			"service": 4,
+			"name": "Eisenbahnfreunde Nossen von %s nach %s",
+			"descriptions": [
+				"Es ist wieder soweit, an diesem Wochenende soll ein Sonderzug der Eisenbahnfreunde Nossen auf dieser sonst wenig befahrenen Strecke verkehren.",
+				"Die Vereinsmitglieder würde historische Fahrzeuge für diesen Sonderzug bevorzugen.",
+				"Zu besonderen Gelegenheiten wird dieser Zug mit einer Dampflok bespannt."
+			],
+			"objects": [
+				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHUS"] }
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
 			"group": 1,
 			"service": 2,
 			"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -49,7 +49,7 @@
 				},
 				{
 					"stations": [ "FD", "FF", "UE P", "LL" ],
-					"pathSuggestion": [ "FD", "FF", "FH", "FFD", "FFU", "FB", "UEI", "UGO", "UE P", "LPLN", "LGOS", "LL" ]
+					"pathSuggestion": [ "FD", "FF", "FH", "FFD", "FFU", "FB", "UEI", "UGO", "UND", "UE P", "LPLN", "LGOS", "LL" ]
 				}
 			],
 			"neededCapacity": [
@@ -125,7 +125,7 @@
 				{ "name": "passengers" },
 				{ "name": "bistroseats" }
 			],
-			"pathSuggestion": [ "FW", "FMZ", "FMB", "FFLF", "FF", "FH", "FFD", "FFU", "FBHF", "FB", "UEI", "UGO", "UE P", "LPLN", "LGOS", "LL" ]
+			"pathSuggestion": [ "FW", "FMZ", "FMB", "FFLF", "FF", "FH", "FFD", "FFU", "FBHF", "FB", "UEI", "UGO", "UND", "UE P", "LPLN", "LGOS", "LL" ]
 		},
 		{
 			"group": 1,
@@ -1502,11 +1502,11 @@
 			"objects": [
 				{
 					"stations": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FB", "UEI", "UGO", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ],
-					"pathSuggestion": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FGTH", "FB", "UEI", "UGO", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ]
+					"pathSuggestion": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FGTH", "FB", "UEI", "UGO", "UND", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ]
 				},
 				{
 					"stations": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FB", "UEI", "UGO", "UE P" ],
-					"pathSuggestion": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FGTH", "FB", "UEI", "UGO", "UE P" ]
+					"pathSuggestion": [ "KK", "KSO", "KW", "EHG", "EHM", "ESOT", "EPD", "HA", "HWAR", "FKW", "FGTH", "FB", "UEI", "UGO", "UND", "UE P" ]
 				}
 			],
 			"neededCapacity": [
@@ -3614,6 +3614,7 @@
 				"Die Strecke ist ideal um von Thüringen nach Norddeutschland oder zurück zu fahren."
 			],
 			"stations": [ "HG", "HEBG", "UL", "ULS", "UGO", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ],
+			"pathSuggestion": [ "HG", "HEBG", "UL", "ULS", "UGO", "UND", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
@@ -5026,7 +5027,7 @@
 				},
 				{
 					"stations": [ "FF", "BFP" ],
-					"pathSuggestion": [ "FF", "FH", "FFD", "FFU", "FB", "UEI", "UGO", "UE P", "UWM", "UGH", "LL", "LBOR", "DR", "BEW", "BDKO", "BC", "BCS", "BFP" ]
+					"pathSuggestion": [ "FF", "FH", "FFD", "FFU", "FB", "UEI", "UGO", "UND", "UE P", "UWM", "UGH", "LL", "LBOR", "DR", "BEW", "BDKO", "BC", "BCS", "BFP" ]
 				},
 				{
 					"stations": [ "HHB", "LHZW" ],
@@ -5820,7 +5821,7 @@
 						"Fahre den verlängerten TEE Goethe von %s bis %s"
 					],
 					"stations": [ "XFPO", "XFMZV", "XFFB", "SSH", "SKL", "RM", "FF", "FFU", "UE P", "LL", "DH", "XTP" ],
-					"pathSuggestion": [ "XFPO", "XFVAR", "XFMEA", "🇫🇷NAA", "XFE", "XFCM", "XFBD", "XFLE", "XFO", "XFPS", "XFMZV", "XFRM", "🇫🇷BDC", "XFFB", "SSH", "SSI", "SRO", "SHO", "SLD", "SKL", "SHY", "RN", "RSD", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FBHF", "FB", "UEI", "UGO", "UE P", "UWM", "UGH", "UNM", "LL", "LBOR", "DR", "DPR", "DCW", "DH", "DHD", "DPI", "DSA", "XTD", "XTU", "XTP" ]
+					"pathSuggestion": [ "XFPO", "XFVAR", "XFMEA", "🇫🇷NAA", "XFE", "XFCM", "XFBD", "XFLE", "XFO", "XFPS", "XFMZV", "XFRM", "🇫🇷BDC", "XFFB", "SSH", "SSI", "SRO", "SHO", "SLD", "SKL", "SHY", "RN", "RSD", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FBHF", "FB", "UEI", "UGO", "UND", "UE P", "UWM", "UGH", "UNM", "LL", "LBOR", "DR", "DPR", "DCW", "DH", "DHD", "DPI", "DSA", "XTD", "XTU", "XTP" ]
 				},
 				{
 					"descriptions": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2813,7 +2813,7 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			],
-			"pathSuggestion": [ "NWH", "NRTD", "NS", "NBKI", "UM", "USL", "UPL", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ]
+			"pathSuggestion": [ "NWH", "NRTD", "NS", "NBKI", "UM", "USL", "UPL", "UND", "UE P", "UWM", "UJW", "UGW", "USK", "UHK", "UG" ]
 		},
 		{
 			"group": 1,
@@ -5035,7 +5035,7 @@
 				},
 				{
 					"stations": [ "UPL", "DP" ],
-					"pathSuggestion": [ "UPL", "UE P", "UWM", "UGH", "LL", "LNK", "DWR", "DRC", "DHN", "DP" ]
+					"pathSuggestion": [ "UPL", "UND", "UE P", "UWM", "UGH", "LL", "LNK", "DWR", "DRC", "DHN", "DP" ]
 				},
 				{
 					"stations": [ "HBNF", "🇳🇱Brn" ],

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3270,7 +3270,7 @@
 				"Zu besonderen Gelegenheiten wird dieser Zug mit einer Dampflok bespannt."
 			],
 			"objects": [
-				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHUS"] },
+				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHU"] },
 				{ 
 					"stations": [ "DNO", "DDE", "LL", "UNM", "UE P", "UA" ],
 					"pathSuggestion": [ "DNO", "DDE", "LBEU", "LBOR", "LL", "UNM", "UGH", "UWN", "UE P", "UA" ]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -3270,7 +3270,11 @@
 				"Zu besonderen Gelegenheiten wird dieser Zug mit einer Dampflok bespannt."
 			],
 			"objects": [
-				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHUS"] }
+				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHUS"] },
+				{ 
+					"stations": [ "DNO", "DDE", "LL", "UNM", "UE P", "UA" ],
+					"pathSuggestion": [ "DNO", "DDE", "LBEU", "LBOR", "LL", "UNM", "UGH", "UWN", "UE P", "UA" ]
+				}
 			],
 			"stopsEverywhere": false,
 			"neededCapacity": [


### PR DESCRIPTION
- [x] Job: Sonderfahrt der Eisenbahnfreunde Nossen nach Holzhau
- [x] overhaul Plaue-Erfurt (insert Arnsdorf)
- [x] Job: Sonderfahrt der Eisenbahnfreunde Nossen nach Arnsdorf
- [x] overhaul Gotha-Erfurt (Neudietendorf)
- [x] fix route Suggestions for jobs between Gotha-Erfurt and Plaue-Erfurt
- [x] Job: Freiberger Eisenbahn RB 83 Freiberg-Holzhau
- [x] review

⚠ Routes Erfurt-Gothe and Erfurth-Plaue now diverge in Neudietendorf, route suggestions should be fixed though.

closes #481 