### PR TITLE
Routen im Norden Tschechiens

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -40450,6 +40450,74 @@
 				}
 			]
 		},
+		{			
+			"name": "SŽDC 089 Liberec-Zittau",
+			"electrified": false,
+			"group": 0,			
+			"maxSpeed": 100,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "DZ",
+					"end": "XTHR",
+					"name": "Neißeviadukt",
+					"length": 6,
+					"maxSpeed": 70,
+					"twistingFactor": 0.24,
+					"neededEquipments": [
+						"DE",
+						"PL",
+						"CZ"
+					]
+				},
+				{
+					"start": "XTHR",
+					"end": "XTCY",
+					"length": 2,
+					"maxSpeed": 90,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XTCY",
+					"end": "XTBKN",
+					"length": 4,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "XTBKN",
+					"end": "XTCR",
+					"length": 2,
+					"maxSpeed": 85,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "XTCR",
+					"end": "XTCA",
+					"length": 1,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "XTCA",
+					"end": "XTMR",
+					"length": 1,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "XTMR",
+					"end": "XTMC",
+					"length": 1,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTMC",
+					"end": "XTL",
+					"length": 5,
+					"twistingFactor": 0.17
+				}
+			]
+		},
 		{
 			"name": "Neißetalbahn",
 			"electrified": false,

--- a/Path.json
+++ b/Path.json
@@ -40450,10 +40450,10 @@
 				}
 			]
 		},
-		{			
+		{
 			"name": "SŽDC 089 Liberec-Zittau",
 			"electrified": false,
-			"group": 0,			
+			"group": 0,
 			"maxSpeed": 100,
 			"neededEquipments": [
 				"CZ"
@@ -40515,6 +40515,144 @@
 					"end": "XTL",
 					"length": 5,
 					"twistingFactor": 0.17
+				}
+			]
+		},
+		{
+			"electrified": false,
+			"group": 0,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "XTL",
+					"end": "XTLHR",
+					"name": "Liberec-Turnov",
+					"length": 4,
+					"maxSpeed": 85,
+					"twistingFactor": 0.8
+				},
+				{
+					"start": "XTLHR",
+					"end": "XTOST",
+					"length": 1,
+					"maxSpeed": 65,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XTOST",
+					"end": "XTKAJ",
+					"length": 2,
+					"maxSpeed": 70,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "XTKAJ",
+					"end": "XTKRU",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "XTKRU",
+					"end": "XTNOV",
+					"name": "Kryštofský tunel",
+					"length": 1,
+					"maxSpeed": 70,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "XTNOV",
+					"end": "XTKZY",
+					"name": "Ještědský tunel",
+					"length": 2,
+					"maxSpeed": 70,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "XTKZY",
+					"end": "XTZDI",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "XTZDI",
+					"end": "XTRTB",
+					"length": 5,
+					"maxSpeed": 65,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "XTRTB",
+					"end": "XTLVV",
+					"length": 2,
+					"maxSpeed": 60,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTLVV",
+					"end": "XTJP",
+					"length": 2,
+					"maxSpeed": 60,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTJP",
+					"end": "XTVVN",
+					"length": 3,
+					"maxSpeed": 90,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTVVN",
+					"end": "XTBRI",
+					"length": 2,
+					"maxSpeed": 90,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTBRI",
+					"end": "XTVG",
+					"length": 1,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTVG",
+					"end": "XTPPR",
+					"length": 2,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTPPR",
+					"end": "XTMM",
+					"length": 2,
+					"maxSpeed": 85,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XTMM",
+					"end": "XTZBO",
+					"length": 5,
+					"maxSpeed": 60,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "XTZBO",
+					"end": "XTVDD",
+					"length": 3,
+					"maxSpeed": 120,
+					"twistingFactor": 0.26
+				},
+				{
+					"start": "XTVDD",
+					"end": "XTCL",
+					"length": 6,
+					"maxSpeed": 120,
+					"twistingFactor": 0.31
 				}
 			]
 		},

--- a/Path.json
+++ b/Path.json
@@ -39628,6 +39628,60 @@
 		},
 		{
 			"electrified": false,
+			"name": "SŽDC 084 Rumburk-Mikulášovice",
+			"group": 1,
+			"maxSpeed": 50,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "XTRU",
+					"end": "XTDKR",
+					"length": 2,
+					"maxSpeed": 55,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTDKR",
+					"end": "XTSKR",
+					"length": 2,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XTSKR",
+					"end": "XTPAN",
+					"length": 2,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "XTPAN",
+					"end": "XTBRT",
+					"length": 1,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XTBRT",
+					"end": "🇨🇿5456559",
+					"length": 3,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇨🇿5456559",
+					"end": "XTMHS",
+					"length": 2,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "XTMHS",
+					"end": "XTMD",
+					"length": 3,
+					"twistingFactor": 0.16
+				}
+			]
+		},
+		{
+			"electrified": false,
 			"group": 1,
 			"maxSpeed": 60,
 			"twistingFactor": 0.3,

--- a/Path.json
+++ b/Path.json
@@ -40451,6 +40451,71 @@
 			]
 		},
 		{
+			"group": 1,
+			"electrified": false,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "DMHD",
+					"end": "DHND",
+					"length": 3,
+					"maxSpeed": 50,
+					"twistingFactor": 0.21,
+					"neededEquipments": []
+				},
+				{
+					"start": "DHND",
+					"end": "DGAU",
+					"length": 3,
+					"maxSpeed": 50,
+					"twistingFactor": 0.31,
+					"neededEquipments": []
+				},
+				{
+					"start": "DGAU",
+					"end": "XTVD",
+					"length": 2,
+					"maxSpeed": 50,
+					"twistingFactor": 0.17,
+					"neededEquipments": [
+						"CZ",
+						"DE"
+					]
+				},
+				{
+					"start": "XTVD",
+					"end": "XTDD",
+					"length": 2,
+					"maxSpeed": 70,
+					"twistingFactor": 0.26
+				},
+				{
+					"start": "XTDD",
+					"end": "XTJD",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.22
+				},
+				{
+					"start": "XTJD",
+					"end": "XTHP",
+					"group": 1,
+					"length": 1,
+					"maxSpeed": 70,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "XTHP",
+					"end": "XTRY",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.16
+				}
+			]
+		},
+		{
 			"name": "SŽDC 089 Liberec-Zittau",
 			"electrified": false,
 			"group": 0,
@@ -51912,12 +51977,12 @@
 				},
 				{
 					"start": "XTKLM",
-					"end": "🇨🇿56719",
+					"end": "XTRY",
 					"length": 2,
 					"twistingFactor": 0.16
 				},
 				{
-					"start": "🇨🇿56719",
+					"start": "XTRY",
 					"end": "XTCHR",
 					"length": 3,
 					"maxSpeed": 90,

--- a/Path.json
+++ b/Path.json
@@ -40657,6 +40657,53 @@
 			]
 		},
 		{
+			"electrified": false,
+			"name": "SŽDC 080 Bakov nad Jizerou - Jedlová",
+			"group": 0,
+			"maxSpeed": 70,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "XTCL",
+					"end": "XTCLS",
+					"length": 1,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "XTCLS",
+					"end": "XTSKA",
+					"length": 6,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "XTSKA",
+					"end": "XTNB",
+					"length": 3,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "XTNB",
+					"end": "XTSVO",
+					"length": 5,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "XTSVO",
+					"end": "XTNHL",
+					"length": 6,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "XTNHL",
+					"end": "XTJL",
+					"length": 2,
+					"twistingFactor": 0.33
+				}
+			]
+		},
+		{
 			"name": "Neißetalbahn",
 			"electrified": false,
 			"maxSpeed": 100,
@@ -51819,13 +51866,13 @@
 				},
 				{
 					"start": "XTCHR",
-					"end": "🇨🇿56759",
+					"end": "XTJL",
 					"length": 5,
 					"maxSpeed": 80,
 					"twistingFactor": 0.36
 				},
 				{
-					"start": "🇨🇿56759",
+					"start": "XTJL",
 					"end": "XTKT",
 					"group": 1,
 					"length": 5,

--- a/Path.json
+++ b/Path.json
@@ -40704,6 +40704,65 @@
 			]
 		},
 		{
+			"electrified": false,
+			"name": "SŽDC 086 Benešov nad Ploučnicí - Česká Lípa",
+			"group": 0,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "XTCL",
+					"end": "XTCLH",
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTCLH",
+					"end": "XTSTR",
+					"length": 5,
+					"maxSpeed": 100,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "XTSTR",
+					"end": "XTHOP",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTHOP",
+					"end": "XTZAN",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XTZAN",
+					"end": "XTSTS",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "XTSTS",
+					"end": "XTFNP",
+					"length": 3,
+					"maxSpeed": 75,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "XTFNP",
+					"end": "XTBP",
+					"length": 2,
+					"maxSpeed": 70,
+					"twistingFactor": 0.29
+				}
+			]
+		},
+		{
 			"name": "Neißetalbahn",
 			"electrified": false,
 			"maxSpeed": 100,
@@ -51929,14 +51988,14 @@
 				},
 				{
 					"start": "XTDH",
-					"end": "🇨🇿56209",
+					"end": "XTBP",
 					"group": 1,
 					"length": 2,
 					"maxSpeed": 85,
 					"twistingFactor": 0.1
 				},
 				{
-					"start": "🇨🇿56209",
+					"start": "XTBP",
 					"end": "XTMV",
 					"length": 2,
 					"maxSpeed": 80,

--- a/Path.json
+++ b/Path.json
@@ -39683,6 +39683,28 @@
 		{
 			"electrified": false,
 			"group": 1,
+			"maxSpeed": 40,
+			"neededEquipments": [
+				"CZ"
+			],
+			"objects": [
+				{
+					"start": "XTPAN",
+					"end": "XTZAH",
+					"length": 2,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "XTZAH",
+					"end": "XTKLP",
+					"length": 2,
+					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": false,
+			"group": 1,
 			"maxSpeed": 60,
 			"twistingFactor": 0.3,
 			"neededEquipments": [

--- a/Station.json
+++ b/Station.json
@@ -40365,6 +40365,185 @@
 			"platforms": 9
 		},
 		{
+			"name": "Liberec-Horní Růžodol",
+			"ril100": "XTLHR",
+			"group": 5,
+			"x": 1159,
+			"y": 167,
+			"proj": 3,
+			"platformLength": 99,
+			"platforms": 3
+		},
+		{
+			"name": "Ostašov",
+			"ril100": "XTOST",
+			"group": 5,
+			"x": 1156,
+			"y": 165,
+			"proj": 3,
+			"platformLength": 81,
+			"platforms": 1
+		},
+		{
+			"name": "Karlov pod Ještědem",
+			"ril100": "XTKAJ",
+			"group": 2,
+			"x": 1152,
+			"y": 164,
+			"proj": 3,
+			"platformLength": 100,
+			"platforms": 2
+		},
+		{
+			"name": "Kryštofovo Údolí",
+			"ril100": "XTKRU",
+			"group": 5,
+			"x": 1146,
+			"y": 164,
+			"proj": 3,
+			"platformLength": 102,
+			"platforms": 1
+		},
+		{
+			"name": "Novina",
+			"ril100": "XTNOV",
+			"group": 5,
+			"x": 1146,
+			"y": 166,
+			"proj": 3,
+			"platformLength": 76,
+			"platforms": 1
+		},
+		{
+			"name": "Křižany",
+			"ril100": "XTKZY",
+			"group": 2,
+			"x": 1143,
+			"y": 167,
+			"proj": 3,
+			"platformLength": 118,
+			"platforms": 2
+		},
+		{
+			"name": "Zdislava",
+			"ril100": "XTZDI",
+			"group": 2,
+			"x": 1138,
+			"y": 164,
+			"proj": 3,
+			"platformLength": 97,
+			"platforms": 1
+		},
+		{
+			"name": "Rynoltice",
+			"ril100": "XTRTB",
+			"group": 2,
+			"x": 1131,
+			"y": 162,
+			"proj": 3,
+			"platformLength": 126,
+			"platforms": 2
+		},
+		{
+			"name": "Lvová",
+			"ril100": "XTLVV",
+			"group": 5,
+			"x": 1126,
+			"y": 162,
+			"proj": 3,
+			"platformLength": 100,
+			"platforms": 1
+		},
+		{
+			"name": "Jablonné v Podještědí",
+			"ril100": "XTJP",
+			"group": 2,
+			"x": 1122,
+			"y": 164,
+			"proj": 3,
+			"platformLength": 178,
+			"platforms": 3
+		},
+		{
+			"name": "Velký Valtinov",
+			"ril100": "XTVVN",
+			"group": 5,
+			"x": 1118,
+			"y": 169,
+			"proj": 3,
+			"platformLength": 144,
+			"platforms": 1
+		},
+		{
+			"name": "Brniště",
+			"ril100": "XTBRI",
+			"group": 2,
+			"x": 1118,
+			"y": 173,
+			"proj": 3,
+			"platformLength": 128,
+			"platforms": 2
+		},
+		{
+			"name": "Velký Grunov",
+			"ril100": "XTVG",
+			"group": 5,
+			"x": 1118,
+			"y": 176,
+			"proj": 3,
+			"platformLength": 121,
+			"platforms": 1
+		},
+		{
+			"name": "Pertoltice pod Ralskem",
+			"ril100": "XTPPR",
+			"group": 5,
+			"x": 1117,
+			"y": 180,
+			"proj": 3,
+			"platformLength": 118,
+			"platforms": 1
+		},
+		{
+			"name": "Mimoň",
+			"ril100": "XTMM",
+			"group": 2,
+			"x": 1116,
+			"y": 183,
+			"proj": 3,
+			"platformLength": 150,
+			"platforms": 3
+		},
+		{
+			"name": "Zákupy-Božíkov",
+			"ril100": "XTZBO",
+			"group": 5,
+			"x": 1107,
+			"y": 179,
+			"proj": 3,
+			"platformLength": 110,
+			"platforms": 1
+		},
+		{
+			"name": "Vlčí Důl-Dobranov",
+			"ril100": "XTVDD",
+			"group": 5,
+			"x": 1102,
+			"y": 181,
+			"proj": 3,
+			"platformLength": 128
+		},
+		{
+			"name": "Česká Lípa Hlavni Nadrazi",
+			"ril100": "XTCL",
+			"group": 1,
+			"x": 1091,
+			"y": 180,
+			"proj": 3,
+			"platformLength": 127,
+			"platforms": 5
+		},
+		{
 			"name": "Hirschfelde",
 			"ril100": "DHE",
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -39972,7 +39972,7 @@
 		},
 		{
 			"name": "Jedlová",
-			"ril100": "🇨🇿56759",
+			"ril100": "XTJL",
 			"group": 2,
 			"x": 1096,
 			"y": 152,
@@ -40542,6 +40542,52 @@
 			"proj": 3,
 			"platformLength": 127,
 			"platforms": 5
+		},
+		{
+			"name": "Česká Lípa střelnice",
+			"ril100": "XTCLS",
+			"group": 5,
+			"x": 1091,
+			"y": 177,
+			"proj": 3,
+			"platformLength": 86,
+			"platforms": 1
+		},
+		{
+			"name": "Skalice u České Lipy",
+			"ril100": "XTSKA",
+			"group": 6,
+			"x": 1090,
+			"y": 169,
+			"proj": 3
+		},
+		{
+			"name": "Novy Bor",
+			"ril100": "XTNB",
+			"group": 2,
+			"x": 1093,
+			"y": 166,
+			"proj": 3,
+			"platformLength": 120,
+			"platforms": 3
+		},
+		{
+			"name": "Svor",
+			"ril100": "XTSVO",
+			"group": 2,
+			"x": 1099,
+			"y": 161,
+			"proj": 3,
+			"platformLength": 61,
+			"platforms": 3
+		},
+		{
+			"name": "Nova Hut v Luzickych Horach",
+			"ril100": "XTNHL",
+			"group": 6,
+			"x": 1098,
+			"y": 154,
+			"proj": 3
 		},
 		{
 			"name": "Hirschfelde",

--- a/Station.json
+++ b/Station.json
@@ -39952,7 +39952,7 @@
 		},
 		{
 			"name": "Rybniště",
-			"ril100": "🇨🇿56719",
+			"ril100": "XTRY",
 			"group": 2,
 			"x": 1087,
 			"y": 146,
@@ -40273,6 +40273,66 @@
 			"platformLength": 140,
 			"platforms": 3,
 			"proj": 3
+		},
+		{
+			"name": "Hainewalde",
+			"ril100": "DHND",
+			"group": 5,
+			"x": 1114,
+			"y": 142,
+			"platformLength": 90,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Großschönau (Sachs)",
+			"ril100": "DGAU",
+			"group": 5,
+			"x": 1108,
+			"y": 144,
+			"platformLength": 90,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Varnsdorf",
+			"ril100": "XTVD",
+			"group": 2,
+			"x": 1105,
+			"y": 142,
+			"proj": 3,
+			"platformLength": 120,
+			"platforms": 3
+		},
+		{
+			"name": "Dolní Podluží",
+			"ril100": "XTDD",
+			"group": 5,
+			"x": 1102,
+			"y": 145,
+			"proj": 3,
+			"platformLength": 84,
+			"platforms": 1
+		},
+		{
+			"name": "Jiřetín pod Jedlovou",
+			"ril100": "XTJD",
+			"group": 5,
+			"x": 1097,
+			"y": 146,
+			"proj": 3,
+			"platformLength": 87,
+			"platforms": 1
+		},
+		{
+			"name": "Horní Podluží",
+			"ril100": "XTHP",
+			"group": 5,
+			"x": 1094,
+			"y": 146,
+			"proj": 3,
+			"platformLength": 53,
+			"platforms": 1
 		},
 		{
 			"group": 1,

--- a/Station.json
+++ b/Station.json
@@ -39861,6 +39861,66 @@
 			"proj": 3
 		},
 		{
+			"name": "Dolní Křečany",
+			"ril100": "XTDKR",
+			"group": 5,
+			"x": 1088,
+			"y": 133,
+			"proj": 3,
+			"platformLength": 43,
+			"platforms": 1
+		},
+		{
+			"name": "Staré Křečany",
+			"ril100": "XTSKR",
+			"group": 5,
+			"x": 1085,
+			"y": 135,
+			"proj": 3,
+			"platformLength": 41,
+			"platforms": 1
+		},
+		{
+			"name": "Panský",
+			"ril100": "XTPAN",
+			"group": 2,
+			"x": 1081,
+			"y": 135,
+			"proj": 3,
+			"platformLength": 120,
+			"platforms": 2
+		},
+		{
+			"name": "Brtníky",
+			"ril100": "XTBRT",
+			"group": 5,
+			"x": 1077,
+			"y": 134,
+			"proj": 3,
+			"platformLength": 40,
+			"platforms": 1
+		},
+		{
+			"name": "Mikulášovice horní nádraží",
+			"ril100": "🇨🇿5456559",
+			"group": 5,
+			"x": 1071,
+			"y": 133,
+			"proj": 3,
+			"platformLength": 40,
+			"platforms": 1
+		},
+		{
+			"name": "Mikulášovice střed",
+			"ril100": "XTMHS",
+			"group": 5,
+			"x": 1066,
+			"y": 132,
+			"proj": 3,
+			"platformLength": 40,
+			"platforms": 1
+		},
+		{
 			"name": "Krásná Lípa",
 			"ril100": "XTKLP",
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -40285,6 +40285,86 @@
 			"proj": 3
 		},
 		{
+			"name": "Hrádek nad Nisou",
+			"ril100": "XTHR",
+			"group": 2,
+			"x": 1133,
+			"y": 150,
+			"proj": 3,
+			"platformLength": 230,
+			"platforms": 3
+		},
+		{
+			"name": "Chotyně",
+			"ril100": "XTCY",
+			"group": 5,
+			"x": 1136,
+			"y": 153,
+			"proj": 3,
+			"platformLength": 62,
+			"platforms": 1
+		},
+		{
+			"name": "Bílý Kostel nad Nisou",
+			"ril100": "XTBKN",
+			"group": 5,
+			"x": 1143,
+			"y": 156,
+			"proj": 3,
+			"platformLength": 62,
+			"platforms": 1
+		},
+		{
+			"name": "Chrastava",
+			"ril100": "XTCR",
+			"group": 2,
+			"x": 1148,
+			"y": 157,
+			"proj": 3,
+			"platformLength": 180,
+			"platforms": 3
+		},
+		{
+			"name": "Chrastava-Andělská Hora",
+			"ril100": "XTCA",
+			"group": 5,
+			"x": 1149,
+			"y": 160,
+			"proj": 3,
+			"platformLength": 72,
+			"platforms": 1
+		},
+		{
+			"name": "Machnin hrad",
+			"ril100": "XTMR",
+			"group": 5,
+			"x": 1151,
+			"y": 161,
+			"proj": 3,
+			"platformLength": 84,
+			"platforms": 1
+		},
+		{
+			"name": "Machnin",
+			"ril100": "XTMC",
+			"group": 5,
+			"x": 1152,
+			"y": 161,
+			"proj": 3,
+			"platformLength": 67,
+			"platforms": 1
+		},
+		{
+			"name": "Liberec",
+			"ril100": "XTL",
+			"group": 1,
+			"x": 1161,
+			"y": 166,
+			"proj": 3,
+			"platformLength": 400,
+			"platforms": 9
+		},
+		{
 			"name": "Hirschfelde",
 			"ril100": "DHE",
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -40052,7 +40052,7 @@
 		},
 		{
 			"name": "Benešov nad Ploučnicí",
-			"ril100": "🇨🇿56209",
+			"ril100": "XTBP",
 			"group": 2,
 			"x": 1060,
 			"y": 170,
@@ -40542,6 +40542,66 @@
 			"proj": 3,
 			"platformLength": 127,
 			"platforms": 5
+		},
+		{
+			"name": "Česká Lípa-Holý vrch",
+			"ril100": "XTCLH",
+			"group": 5,
+			"x": 1090,
+			"y": 179,
+			"proj": 3,
+			"platformLength": 128,
+			"platforms": 1
+		},
+		{
+			"name": "Stružnice",
+			"ril100": "XTSTR",
+			"group": 5,
+			"x": 1080,
+			"y": 176,
+			"proj": 3,
+			"platformLength": 150,
+			"platforms": 3
+		},
+		{
+			"name": "Horní Police",
+			"ril100": "XTHOP",
+			"group": 2,
+			"x": 1073,
+			"y": 175,
+			"proj": 3,
+			"platformLength": 93,
+			"platforms": 2
+		},
+		{
+			"name": "Žandov",
+			"ril100": "XTZAN",
+			"group": 5,
+			"x": 1072,
+			"y": 174,
+			"proj": 3,
+			"platformLength": 162,
+			"platforms": 1
+		},
+		{
+			"name": "Starý Šachov",
+			"ril100": "XTSTS",
+			"group": 5,
+			"x": 1070,
+			"y": 172,
+			"proj": 3,
+			"platformLength": 130,
+			"platforms": 1
+		},
+		{
+			"name": "Františkov n.Ploučnicí",
+			"ril100": "XTFNP",
+			"group": 5,
+			"x": 1064,
+			"y": 172,
+			"proj": 3,
+			"platformLength": 100,
+			"platforms": 2
 		},
 		{
 			"name": "Česká Lípa střelnice",

--- a/Station.json
+++ b/Station.json
@@ -39921,6 +39921,16 @@
 			"platforms": 1
 		},
 		{
+			"name": "Zahrady u Rumburka",
+			"ril100": "XTZAH",
+			"group": 5,
+			"x": 1084,
+			"y": 137,
+			"proj": 3,
+			"platformLength": 40,
+			"platforms": 1
+		},
+		{
 			"name": "Krásná Lípa",
 			"ril100": "XTKLP",
 			"group": 5,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2954,6 +2954,29 @@
 		},
 		{
 			"group": 1,
+			"name": "Bummelzug von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre über Nebenstrecken durch Tschechien von %s nach %s.",
+				"Bediene diese Strecke mit geringem Verkehrsaufkommen."
+			],
+			"objects": [
+				{
+					"name": "ČD Os 26026 von %s nach %s",
+					"stations": [ "XTRU", "XTPAN", "XTKLP", "XTMD" ]
+				},
+				{
+					"name": "Trilex TL T2",
+					"stations": [ "XTRU", "XTPAN", "XTMD" ]
+				}
+			],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
 			"name": "ČD Os von %s nach %s",
 			"service": 2,
 			"descriptions": [


### PR DESCRIPTION
depends on #745  
related: #684 

- [x] stations/route Zittau-Liberec
- [x] stations/route Liberec-Česká Lípa
- [x] stations/route Česká Lípa-Jedlová
- [x] ~~update pathSuggestion for trains running through Jedlová~~ no such jobs yet
- [x] stations/route Benešov nad Ploučnicí – Česká Lípa
- [x] ~~update pathSuggestion for trains running through Benešov nad Ploučnicí~~ no such jobs yet
- [x] stations/route Rybniště - Mittelherwigsdorf (Sachs)
- [x] ~~update pathSuggestion for trains running through Rybniště~~ no such jobs yet

⚠ Changing Station Code for Jedlová from 🇨🇿56759 to XTJL  
⚠ Changing Station Code for Benešov nad Ploučnicí from 🇨🇿56209 to XTBP  
⚠ Changing Station Code for Rybniště from 🇨🇿56719 to XTRY  

jobs will come later