### PR TITLE
Entfernung des Münchener Nordrings aus den Files

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -27011,18 +27011,6 @@
 			]
 		},
 		{
-			"start": "MN",
-			"end": "MOL",
-			"electrified": true,
-			"group": 0,
-			"length": 11,
-			"maxSpeed": 120,
-			"twistingFactor": 0,
-			"neededEquipments": [
-				"DE"
-			]
-		},
-		{
 			"electrified": true,
 			"maxSpeed": 180,
 			"neededEquipments": [
@@ -42458,42 +42446,6 @@
 					"start": "LEST",
 					"end": "LS",
 					"length": 12
-				}
-			]
-		},
-		{
-			"electrified": true,
-			"group": 0,
-			"maxSpeed": 120,
-			"twistingFactor": 0,
-			"neededEquipments": [
-				"DE"
-			],
-			"name": "Nordring",
-			"objects": [
-				{
-					"start": "MJK",
-					"end": "MFM",
-					"length": 4,
-					"twistingFactor": 0.29
-				},
-				{
-					"start": "MFM",
-					"end": "MMBH",
-					"length": 3,
-					"twistingFactor": 0.13
-				},
-				{
-					"start": "MMBH",
-					"end": "MN",
-					"length": 4,
-					"twistingFactor": 0.13
-				},
-				{
-					"start": "MN",
-					"end": "MDA",
-					"length": 8,
-					"twistingFactor": 0.13
 				}
 			]
 		},

--- a/Station.json
+++ b/Station.json
@@ -65772,32 +65772,6 @@
 			"proj": 3
 		},
 		{
-			"name": "München-Freimann",
-			"ril100": "MFM",
-			"group": 5,
-			"x": 699,
-			"y": 594,
-			"proj": 3
-		},
-		{
-			"name": "München-Milbertshofen",
-			"ril100": "MMBH",
-			"group": 5,
-			"x": 692,
-			"y": 594,
-			"proj": 3
-		},
-		{
-			"name": "München Nord Rbf",
-			"ril100": "MN",
-			"group": 2,
-			"x": 676,
-			"y": 583,
-			"platformLength": 452,
-			"platforms": 14,
-			"proj": 3
-		},
-		{
 			"name": "Kungsbacka",
 			"ril100": "XVKA",
 			"group": 2,


### PR DESCRIPTION
Da es zu unübersichtlich wurde, habe ich mich entschieden den Nordring rauszustreichen. Hier is die Version ohne Nordring.