### PR TITLE
Korigierung der Länge des Alstom Coradia LINT 41

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -3787,7 +3787,7 @@
 			"speed": 140,
 			"weight": 68,
 			"force": 87,
-			"length": 27,
+			"length": 42,
 			"drive": 2,
 			"reliability": 0.9,
 			"cost": 300000,


### PR DESCRIPTION
Änderung der Länge des LINT 41 von 27 zu 42 Metern.