### PR TITLE
Revert "North American Cars restriction only for use in North America"

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -8337,7 +8337,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 240000,
 			"exchangeTime": 180,
 			"capacity": [
@@ -8371,7 +8370,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 240000,
 			"exchangeTime": 180,
 			"capacity": [
@@ -8388,7 +8386,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 300000,
 			"exchangeTime": 120,
 			"capacity": [
@@ -8405,7 +8402,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 350000,
 			"exchangeTime": 180,
 			"capacity": [
@@ -8423,7 +8419,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 320000,
 			"exchangeTime": 180,
 			"capacity": [
@@ -8440,7 +8435,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 280000,
 			"exchangeTime": 80,
 			"capacity": [
@@ -8473,7 +8467,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 250000,
 			"exchangeTime": 180,
 			"capacity": [
@@ -8491,7 +8484,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 250000,
 			"exchangeTime": 50,
 			"capacity": [
@@ -8508,7 +8500,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 260000,
 			"exchangeTime": 60,
 			"capacity": [
@@ -8525,7 +8516,6 @@
 			"length": 26,
 			"drive": 0,
 			"reliability": 1,
-			"equipments": ["US", "CA"],
 			"cost": 230000,
 			"exchangeTime": 70,
 			"capacity": [
@@ -8543,7 +8533,6 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 225000,
-			"equipments": ["US", "CA"],
 			"exchangeTime": 120,
 			"capacity": [
 				{"name": "passengers", "value": 80}
@@ -9082,7 +9071,6 @@
 			"drive": 0,
 			"reliability": 0.95,
 			"cost": 250000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "cars", "value": 14}
 			]
@@ -9152,7 +9140,6 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 240000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "wood", "value": 80}
 			]
@@ -9222,7 +9209,6 @@
 			"drive": 0,
 			"reliability": 0.8,
 			"cost": 190000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "oil", "value": 89}
 			]
@@ -9290,7 +9276,6 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 180000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "coal", "value": 91}
 			]
@@ -9377,7 +9362,6 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 130000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "containers", "value": 4}
 			]
@@ -9429,7 +9413,6 @@
 			"drive": 0,
 			"reliability": 1,
 			"cost": 600000,
-			"equipments": ["US", "CA"],
 			"capacity": [
 				{"name": "castor", "value": 1}
 			]


### PR DESCRIPTION
Guter Punkt, nur stelle ich gerade fest, dass man wagen technisch aktuell gar nicht auf einzelne Länder begrenzen kann. Länderzulassungen werden aktuell nur bei Triebfahrzeugen geprüft.