### PR TITLE
Neue/aktualiserte Mireo Plus-Züge

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -3347,7 +3347,7 @@
 			"group": 2,
 			"name": "Siemens Mireo Plus H",
 			"shortcut": "BR 563",
-			"speed": 160,
+			"speed": 140,
 			"weight": 101,
 			"force": 112,
 			"length": 63,
@@ -3359,7 +3359,7 @@
 			"exchangeTime": 60,
 			"maxConnectedUnits": 2,
 			"capacity": [
-				{"name": "passengers", "value": 160}
+				{"name": "passengers", "value": 130}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -3363,6 +3363,26 @@
 			]
 		},
 		{
+			"id": 5631,
+			"group": 2,
+			"name": "Siemens Mireo Plus B",
+			"shortcut": "BR 563",
+			"speed": 140,
+			"weight": 101,
+			"force": 112,
+			"length": 63,
+			"drive": 3,
+			"reliability": 0.85,
+			"cost": 850000,
+			"operationCosts": 50,
+			"range": 120,
+			"exchangeTime": 60,
+			"maxConnectedUnits": 2,
+			"capacity": [
+				{"name": "passengers", "value": 125}
+			]
+		},
+		{
 			"id": 654,
 			"group": 2,
 			"name": "Alstom Coradia iLint",


### PR DESCRIPTION
Ich habe den Mireo Plus H aktualisiert und den Mireo Plus B eingefügt. Laut den Datenblättern von Siemens zu den aktuell eingesetzten Exemplaren haben beide Mireos hier eine Höchstgeschwindigkeit von nur 140km/h. Dem Plus B habe ich auch die Zuverlässigkeit leicht heruntergedreht, weil die Plus B der NEB wegen Fahrzeugstörung oft ausgefallen sind.