### PR TITLE
Neuer BE/NL/DE-fähiger nicht-XL Flirt 3

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -939,6 +939,26 @@
 			]
 		},
 		{
+			"id": 2427,
+			"group": 2,
+			"service": 2,
+			"name": "Stadler FLIRT 3",
+			"shortcut": "BR 1427",
+			"speed": 160,
+			"weight": 100,
+			"force": 100,
+			"length": 63,
+			"drive": 1,
+			"reliability": 1,
+			"cost": 450000,
+			"operationCosts": 40,
+			"maxConnectedUnits": 3,
+			"equipments": ["NL", "DE", "BE", "ETCS"],
+			"capacity": [
+				{"name": "passengers", "value": 158}
+			]
+		},
+		{
 			"id": 3427,
 			"group": 2,
 			"service": 2,


### PR DESCRIPTION
Flirt 3 (nicht-XL) der den Dreiländerzug zwischen Aachen, Maastricht und Lüttich bzw. den RE19 zwischen Düsseldorf und Arnhem abbildet. ETCS ist auch mit drin für die Güterstrecke zwischen Emmerich und Zevenaar.

ID-Nummer ist eigentlich falsch, aber die BR-Nummer für den Flirt 3 ist schon für den Flirt 3 Akku vergeben.