### PR TITLE
Aktualisierter New Pendolino mit polnischer Einsatzfähigkeit

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -523,7 +523,7 @@
 			"reliability": 1,
 			"cost": 2500000,
 			"operationCosts": 70,
-			"equipments": ["ETCS", "CH", "AT", "IT", "ES", "DE"],
+			"equipments": ["ETCS", "CH", "AT", "IT", "ES", "DE", "PL"],
 			"maxConnectedUnits": 2,
 			"exchangeTime": 120,
 			"capacity": [


### PR DESCRIPTION
Der New Pendolino verkehrt als [Baureihe ED250](https://de.wikipedia.org/wiki/PKP-Baureihe_ED250) der PKP in Polen.

(Die polnischen Einheiten sollten auch eine Zulassung für Tschechien erhalten *können*, das ist aber noch nicht passiert also ich habe das erstmal weggelassen.)