### PR TITLE
Fixed task

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8360,7 +8360,7 @@
 				"Fahre diesen Regionalzug von %s nach %s.",
 				"Verbinde Kaunas mit der Grenze zu Polen."
 			],
-			"stations": [ "🇵🇱TRA", "🇱🇹SES", "🇱🇹KZR", "🇱🇹KUN" ],
+			"stations": [ "🇵🇱🇱🇹", "🇱🇹SES", "🇱🇹KZR", "🇱🇹KUN" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }


### PR DESCRIPTION
Ich glaube "Regionalzug von 🇵🇱 Trakiszki nach 🇱🇹 Kaunas" ist bisher unmöglich, da sowohl russische Breitspur als auch (polnische) Normalspur angefahren wird. Diesen Bahnhof zu ändern sollte das beheben.