### PR TITLE
Add FR to class 92

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5304,7 +5304,7 @@
 			"reliability": 1,
 			"cost": 380000,
 			"operationCosts": 120,
-			"equipments": ["GB", "Eurotunnel", "TVM", "BG", "RO", "HR"]
+			"equipments": ["GB", "Eurotunnel", "FR", "TVM", "BG", "RO", "HR"]
 		},
 		{
 			"id": 7091,


### PR DESCRIPTION
Aus wikipedia

> In France, a number were also owned and operated by [SNCF](https://en.m.wikipedia.org/wiki/SNCF); these were classified as CC 92000 on French railways.

Sonst kommt man nicht durch den Eurotunnel :)