### PR TITLE
Hinzufügung RS Zero

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -3924,6 +3924,26 @@
 			]
 		},
 		{
+			"id": 550,
+			"group": 2,
+			"name": "Stadler RS Zero",
+			"shortcut": "BR 550",
+			"speed": 120,
+			"weight": 70,
+			"force": 55,
+			"length": 27,
+			"drive": 5,
+			"reliability": 1,
+			"cost": 500000,
+			"operationCosts": 75,
+			"maxConnectedUnits": 6,
+			"exchangeTime": 40,
+			"equipments": ["ETCS", "DE"],
+			"capacity": [
+				{"name": "passengers", "value": 75}
+			]
+		},
+		{
 			"id": 872100,
 			"group": 2,
 			"name": "SNCF X 2100",


### PR DESCRIPTION
Hinzufügung des RS Zero von Stadler in der einteiligen Wasserstoff-Version, wie sie letztes Jahr präsentiert wurde.