### PR TITLE
Frankreichzulassung Vectron MS

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5062,7 +5062,7 @@
 			"length": 19,
 			"drive": 1,
 			"reliability": 1,
-			"cost": 650000,
+			"cost": 700000,
 			"operationCosts": 110,
 			"equipments": ["ETCS", "CZ", "CH", "AT", "NL", "BE", "IT", "FR", "PL", "DK", "SE", "NO", "DE", "BG", "HR", "RO", "SK", "SI", "HU", "TR", "RS"]
 		},

--- a/Train.json
+++ b/Train.json
@@ -5064,7 +5064,7 @@
 			"reliability": 1,
 			"cost": 650000,
 			"operationCosts": 110,
-			"equipments": ["ETCS", "CZ", "CH", "AT", "NL", "BE", "IT", "PL", "DK", "SE", "NO", "DE", "BG", "HR", "RO", "SK", "SI", "HU", "TR", "RS"]
+			"equipments": ["ETCS", "CZ", "CH", "AT", "NL", "BE", "IT", "FR", "PL", "DK", "SE", "NO", "DE", "BG", "HR", "RO", "SK", "SI", "HU", "TR", "RS"]
 		},
 		{
 			"id": 248,


### PR DESCRIPTION
Ich habe die der Vectron MS Frankreich hinzugefügt, nachdem Siemens den ersten Auftrag für frankreichtaugliche Vectrons bekommen hat.