### PR TITLE
Add ETCS to Prima II

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -6146,7 +6146,7 @@
 			"reliability": 1,
 			"cost": 520000,
 			"operationCosts": 95,
-			"equipments": ["MA"]
+			"equipments": ["MA", "ETCS"]
 		},
 		{
 			"id": 5,


### PR DESCRIPTION
Laut Wikipedia soll die Prima II ETCS unterstützen: https://de.wikipedia.org/wiki/Alstom_Prima#cite_note-10

Fixes #760 

Ist eine Anpassung des Preises notwendig?