### PR TITLE
Reduce operating costs of US locomotives

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5131,7 +5131,7 @@
 			"range": 1600,
 			"reliability": 1,
 			"cost": 520000,
-			"operationCosts": 120,
+			"operationCosts": 110,
 			"equipments": [ "US", "CA" ]
 		},
 		{
@@ -5146,7 +5146,7 @@
 			"range": 1000,
 			"reliability": 1,
 			"cost": 500000,
-			"operationCosts": 130,
+			"operationCosts": 120,
 			"equipments": [ "US", "CA" ]
 		},
 		{
@@ -5161,7 +5161,7 @@
 			"drive": 1,
 			"reliability": 1.0,
 			"cost": 550000,
-			"operationCosts": 110,
+			"operationCosts": 90,
 			"equipments": [
 				"US"
 			]
@@ -5177,7 +5177,7 @@
 			"drive": 1,
 			"reliability": 0.9,
 			"cost": 450000,
-			"operationCosts": 120,
+			"operationCosts": 110,
 			"equipments": ["US"]
 		},
 		{
@@ -5192,7 +5192,7 @@
 			"drive": 1,
 			"reliability": 0.8,
 			"cost": 500000,
-			"operationCosts": 130,
+			"operationCosts": 100,
 			"equipments": ["US"]
 		},
 		{
@@ -5223,7 +5223,7 @@
 			"weight": 200,
 			"reliability": 0.98,
 			"cost": 720000,
-			"operationCosts": 170,
+			"operationCosts": 150,
 			"equipments": [
 				"US", "CA"
 			]
@@ -6287,7 +6287,7 @@
 			"drive": 2,
 			"reliability": 0.8,
 			"cost": 250000,
-			"operationCosts": 140,
+			"operationCosts": 130,
 			"equipments": [ "US", "CA" ]
 		},
 		{
@@ -6301,7 +6301,7 @@
 			"drive": 2,
 			"reliability": 0.8,
 			"cost": 325000,
-			"operationCosts": 130,
+			"operationCosts": 120,
 			"equipments": [ "US", "CA" ]
 		},
 		{
@@ -6316,7 +6316,7 @@
 			"drive": 2,
 			"reliability": 1,
 			"cost": 450000,
-			"operationCosts": 120,
+			"operationCosts": 110,
 			"equipments": [ "US", "CA" ]
 		},
 		{


### PR DESCRIPTION
In der Hoffung, die US-Routen etwas profitabler zu machen habe ich die Betriebskosten etwas reduziert. (#811)

Die Betriebskosten von Elektroloks wurden erheblich gesenkt (z.b Der Cities Sprinter ist jetzt genau so teuer wie der verwandte EuroSprinter). Die anderen loks wurden vergleichbar, in Anlehnung an ihr alter und den Betriebskosten der EU varianten, neu bepreist.