### PR TITLE
Neue Strecke: Strasbourg–Lauterbourg–Wörth

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -7303,7 +7303,6 @@
 					"maxSpeed": 75,
 					"twistingFactor": 0.12,
 					"neededEquipments": [
-						"FR",
 						"DE"
 					]
 				},

--- a/Path.json
+++ b/Path.json
@@ -7183,6 +7183,185 @@
 			]
 		},
 		{
+			"objects": [
+				{
+					"start": "XFSTG",
+					"end": "🇫🇷BHM",
+					"name": "Ligne de Noisy-le-sec à Strasbourg-Ville",
+					"electrified": false,
+					"group": 0,
+					"length": 2,
+					"maxSpeed": 130,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷BHM",
+					"end": "🇫🇷LWL",
+					"electrified": false,
+					"group": 0,
+					"length": 8,
+					"maxSpeed": 100,
+					"twistingFactor": 0.03,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷LWL",
+					"end": "🇫🇷HRL",
+					"electrified": false,
+					"group": 0,
+					"length": 9,
+					"maxSpeed": 100,
+					"twistingFactor": 0.13,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷HRL",
+					"end": "🇫🇷DRS",
+					"electrified": false,
+					"group": 0,
+					"length": 5,
+					"maxSpeed": 100,
+					"twistingFactor": 0.18,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷DRS",
+					"end": "🇫🇷ZHM",
+					"electrified": false,
+					"group": 1,
+					"length": 4,
+					"maxSpeed": 100,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷ZHM",
+					"end": "🇫🇷RHI",
+					"electrified": false,
+					"group": 0,
+					"length": 17,
+					"maxSpeed": 100,
+					"twistingFactor": 0.3,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷RHI",
+					"end": "🇫🇷SSZ",
+					"electrified": false,
+					"group": 1,
+					"length": 5,
+					"maxSpeed": 100,
+					"twistingFactor": 0.09,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷SSZ",
+					"end": "🇫🇷MHQ",
+					"electrified": false,
+					"group": 1,
+					"length": 4,
+					"maxSpeed": 100,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "🇫🇷MHQ",
+					"end": "XFLTG",
+					"electrified": false,
+					"group": 0,
+					"length": 5,
+					"maxSpeed": 100,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"FR"
+					]
+				},
+				{
+					"start": "XFLTG",
+					"end": "RBRG",
+					"name": "Bienwaldbahn",
+					"electrified": false,
+					"group": 0,
+					"length": 2,
+					"maxSpeed": 75,
+					"twistingFactor": 0.12,
+					"neededEquipments": [
+						"FR",
+						"DE"
+					]
+				},
+				{
+					"start": "RBRG",
+					"end": "RNBU",
+					"name": "Bienwaldbahn",
+					"electrified": false,
+					"group": 0,
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"DE"
+					]
+				},
+				{
+					"start": "RNBU",
+					"end": "RHGB",
+					"name": "Bienwaldbahn",
+					"electrified": false,
+					"group": 1,
+					"length": 2,
+					"maxSpeed": 80,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"DE"
+					]
+				},
+				{
+					"start": "RHGB",
+					"end": "RMAI",
+					"name": "Bienwaldbahn",
+					"electrified": false,
+					"group": 0,
+					"length": 2,
+					"maxSpeed": 80,
+					"twistingFactor": 0.01,
+					"neededEquipments": [
+						"DE"
+					]
+				},
+				{
+					"start": "RMAI",
+					"end": "RWRT",
+					"name": "Bienwaldbahn",
+					"electrified": true,
+					"group": 0,
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.28,
+					"neededEquipments": [
+						"DE"
+					]
+				}
+			]
+		},
+		{
 			"electrified": true,
 			"group": 2,
 			"name": "LGV Interconnexion Est",

--- a/Station.json
+++ b/Station.json
@@ -7456,6 +7456,136 @@
 			"proj": 3
 		},
 		{
+			"name": "Bischheim",
+			"ril100": "🇫🇷BHM",
+			"group": 2,
+			"x": 166,
+			"y": 524,
+			"platformLength": 180,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "La Wantzenau",
+			"ril100": "🇫🇷LWL",
+			"group": 2,
+			"x": 177,
+			"y": 515,
+			"platformLength": 225,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Herrlisheim",
+			"ril100": "🇫🇷HRL",
+			"group": 2,
+			"x": 189,
+			"y": 504,
+			"platformLength": 180,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Drusenheim",
+			"ril100": "🇫🇷DRS",
+			"group": 2,
+			"x": 194,
+			"y": 498,
+			"platformLength": 310,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Sessenheim",
+			"ril100": "🇫🇷ZHM",
+			"group": 2,
+			"x": 200,
+			"y": 493,
+			"platformLength": 219,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Roppenheim",
+			"ril100": "🇫🇷RHI",
+			"group": 2,
+			"x": 210,
+			"y": 484,
+			"platformLength": 324,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Seltz",
+			"ril100": "🇫🇷SSZ",
+			"group": 2,
+			"x": 215,
+			"y": 476,
+			"platformLength": 230,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Munchhausen",
+			"ril100": "🇫🇷MHQ",
+			"group": 2,
+			"x": 221,
+			"y": 471,
+			"platformLength": 232,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Lauterbourg",
+			"ril100": "XFLTG",
+			"group": 2,
+			"x": 227,
+			"y": 464,
+			"platformLength": 280,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Berg (Pfalz)",
+			"ril100": "RBRG",
+			"group": 2,
+			"x": 231,
+			"y": 462,
+			"platformLength": 120,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Neuburg (Rhein)",
+			"ril100": "RNBU",
+			"group": 2,
+			"x": 234,
+			"y": 460,
+			"platformLength": 120,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Hagenbach",
+			"ril100": "RHGB",
+			"group": 2,
+			"x": 237,
+			"y": 456,
+			"platformLength": 120,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Maximiliansau Im Rüsten",
+			"ril100": "RMAI",
+			"group": 2,
+			"x": 240,
+			"y": 453,
+			"platformLength": 120,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
 			"name": "Solana Beach",
 			"ril100": "🇺🇸SOL",
 			"group": 2,
@@ -43205,7 +43335,7 @@
 		},
 		{
 			"group": 0,
-			"name": "Straßburg Ville",
+			"name": "Strasbourg Ville",
 			"ril100": "XFSTG",
 			"x": 157,
 			"y": 527,
@@ -60512,6 +60642,14 @@
 			"group": 5,
 			"x": 1237,
 			"y": 1067,
+			"proj": 3
+		},
+		{
+			"name": "Herrlisheim (Bas-Rhin)",
+			"ril100": "🇫🇷HRL",
+			"group": 2,
+			"x": 189,
+			"y": 504,
 			"proj": 3
 		},
 		{

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1194,6 +1194,35 @@
 			"pathSuggestion": [ "ANB", "ADM" ]
 		},
 		{
+			"name": "TER/RB von %s nach %s",
+			"descriptions": [
+				"Fahre über die Bienwaldbahn von %s nach %s.",
+				"Fahre abseits nützlicher Fahrplanlagen, um möglichst keine Anschlüsse in Strasbourg zu ermöglichen.",
+				"Manche Züge fahren sogar über die Grenze. Schockierend, oder?"
+			],
+			"objects": [
+				{
+					"stations": [ "XFSTG", "🇫🇷BHM", "🇫🇷LWL", "🇫🇷HRL", "🇫🇷DRS", "🇫🇷ZHM", "🇫🇷RHI", "🇫🇷SSZ", "🇫🇷MHQ", "XFLTG", "RBRG", "RNBU", "RHGB", "RMAI", "RWRT" ],
+					"pathSuggestion": [ "XFSTG", "🇫🇷BHM", "🇫🇷LWL", "🇫🇷HRL", "🇫🇷DRS", "🇫🇷ZHM", "🇫🇷RHI", "🇫🇷SSZ", "🇫🇷MHQ", "XFLTG", "RBRG", "RNBU", "RHGB", "RMAI", "RWRT" ]
+				},
+				{
+					"stations": [ "XFSTG", "🇫🇷BHM", "🇫🇷LWL", "🇫🇷HRL", "🇫🇷DRS", "🇫🇷ZHM", "🇫🇷RHI", "🇫🇷SSZ", "🇫🇷MHQ", "XFLTG" ],
+					"pathSuggestion": [ "XFSTG", "🇫🇷BHM", "🇫🇷LWL", "🇫🇷HRL", "🇫🇷DRS", "🇫🇷ZHM", "🇫🇷RHI", "🇫🇷SSZ", "🇫🇷MHQ", "XFLTG" ]
+				},
+				{
+					"stations": [ "XFLTG", "RBRG", "RNBU", "RHGB", "RMAI", "RWRT" ],
+					"pathSuggestion": [ "XFLTG", "RBRG", "RNBU", "RHGB", "RMAI", "RWRT" ]
+				}
+			],
+			
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"stopsEverywhere": true,
+			"service": 3
+		},
+		{
 			"name": "Brightline von %s nach %s",
 			"descriptions": [
 				"Fahre für Brightline durch Florida von %s nach %s.",
@@ -3249,7 +3278,7 @@
 				"Dieser RB fährt bis ins deutsch-tschechisch-polnische Dreiländereck.",
 				"Der Abschnitt zwischen Görlitz und Zittau liegt teilweise in polnischem Gebiet."
 			],
-			"stations": [ "BC", "BCS", "DG",  "DZ" ],
+			"stations": [ "BC", "BCS", "DG", "DZ" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -3390,8 +3419,12 @@
 				"Der Musikwinkel-Express wird ein mal im Monat mit Ferkeltaxen gefahren."
 			],
 			"objects": [
-				{ "stations": [ "DAD", "DZA"] },
-				{ "stations": [ "DMB", "DSNO"] }
+				{
+					"stations": [ "DAD", "DZA" ]
+				},
+				{
+					"stations": [ "DMB", "DSNO" ]
+				}
 			],
 			"stopsEverywhere": true,
 			"neededCapacity": [
@@ -3408,7 +3441,9 @@
 				"Zu besonderen Gelegenheiten wird dieser Zug mit einer Dampflok bespannt."
 			],
 			"objects": [
-				{ "stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHU"] },
+				{
+					"stations": [ "DNO", "DGVB", "DFR", "DMUL", "DHU" ]
+				},
 				{
 					"stations": [ "DNO", "DDE", "LL", "UNM", "UWM", "UE P", "UA" ],
 					"pathSuggestion": [ "DNO", "DDE", "LBEU", "LBOR", "LL", "UNM", "UGH", "UWM", "UE P", "UND", "UA" ]
@@ -3427,7 +3462,7 @@
 				"Fahre den RB 83 der Freiberger Eisenbahn von %s nach %s.",
 				"Auch das Erzgebirge ist bei Urlaubern beliebt."
 			],
-			"stations": [ "DFR", "DMUL", "DHU"],
+			"stations": [ "DFR", "DMUL", "DHU" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -4007,7 +4042,7 @@
 			"descriptions": [
 				"Für ein Event in der Region hat der VRR einen Rhein-Ruhr-Express Verstärkerzug von %s nach %s bestellt."
 			],
-			"stations": [ "KK","KLMI", "KD", "KDFF", "EDG", "EE" ],
+			"stations": [ "KK", "KLMI", "KD", "KDFF", "EDG", "EE" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
@@ -6348,7 +6383,7 @@
 			"objects": [
 				{
 					"stations": [ "XJBC", "XJLP", "XJNI" ],
-					"pathSuggestion": ["XJBC", "XJBR", "XJLP", "XJNI"]
+					"pathSuggestion": [ "XJBC", "XJBR", "XJLP", "XJNI" ]
 				},
 				{
 					"stations": [ "XRZ", "XRT", "XJSI", "XJBC" ],


### PR DESCRIPTION
Ich habe die Bahnstrecke von Strasbourg über Lauterbourg nach Wörth (Rhein) hinzugefügt, inklusive einer Ausschreibung für einen TER/RB. Vielleicht könnte noch Güterverkehr dazukommen, da war ich aber ein bisschen unkreativ.