### PR TITLE
Add Hungary and Sweden to Br 182

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5024,7 +5024,7 @@
 			"reliability": 1,
 			"cost": 400000,
 			"operationCosts": 90,
-			"equipments": ["ETCS", "AT", "CH", "DE"]
+			"equipments": ["ETCS", "AT", "CH", "DE","HU","SE"]
 		},
 		{
 			"id": 183,


### PR DESCRIPTION
source for SE: https://web.archive.org/web/20140728185153/http://www.hectorrail.com/docs/br242-14.pdf
and MAV/GySev operate Rh1116s in Hungary