### PR TITLE
Mehr mitteleuropäische Güterzüge

### DIFF
--- a/DelayModel.json
+++ b/DelayModel.json
@@ -35,6 +35,18 @@
 				{
 					"name": "Die Brandmeldeanlage hat angeschlagen. Es musste nach dem Grund geschaut werden",
 					"delay": 400
+				},
+				{
+					"name": "Ein Rentnerehepaar gab Sh3, um den Lokführer nach dem Weg zu fragen.",
+					"delay": 1000
+				},
+				{
+					"name": "Die Strecke wurde noch durch eine 218 mit n-Wagen blockiert.",
+					"delay": 1000
+				},
+				{
+					"name": "Wegen eines Trainspotters, der durch die Polizei abgeholt werden musste, war die Strecke kurzzeitig gesperrt.",
+					"delay": 1000
 				}
 			]
 		},
@@ -84,10 +96,21 @@
 				{
 					"name": "Der ausgeliehene Lokführer ist mit der PZB nicht vertraut und hat diese deaktiviert.",
 					"delay": 1000
+				},{
+					"name": "Wegen dauernder Überholungen ist der Lokführer ins Kino gegangen und hat die Weiterfahrt verpasst.",
+					"delay": 1000
 				},
 				{
 					"name": "Der Lokführer hatte sich bei einem Toilettengang während eines Betriebshaltes aus dem Führerstand ausgeschlossen und musste das Schloss mit einem Schotterstein aufbrechen.",
 					"delay": 800
+				},
+				{
+					"name": "Der Zug wurde in ein zu kurzes Überholgleis geleitet, was erst nach Diskussion mit dem Fahrdienstleiter gelöst werden konnte.",
+					"delay": 1000
+				},
+				{
+					"name": "Der Lokführer machte während der Fahrt Fotos für Social Media, und musste nach einer spontanen EBA-Kontrolle durch eine Ersatzlokführerin ersetzt werden.",
+					"delay": 1000
 				}
 			]
 		},
@@ -162,6 +185,13 @@
 				},
 				{
 					"name": "Ein Abteil wurde wegen Läusebfall geräumt, an die Fahrgäste wurden Kämme ausgeteilt."
+				},
+				{
+					"name": "Ein Fahrgast hat sich ins Fahrgastinformationssystem gehackt und einen falschen Unterwegshalt eingetragen. Diverse Fahrgäste mussten erst wieder eingesammelt werden."
+				},
+				{
+					"name": "Eine Fahrgästin stieg während eines Haltes vor einem roten Signal aus, um mit ihrem Hund zu gehen, und musste erst wieder eingesammelt werden.",
+					"delay": 800
 				}
 			]
 		},
@@ -234,6 +264,10 @@
 				{
 					"name": "In einem Auto wurde ein blinder Passagier entdeckt, der von der Polizei abgeholt wurde.",
 					"delay": 1000
+				},
+				{
+					"name": "Bei einem Auto wurde die Alarmanlage aktiviert, die der genervte Lokführer vor der Weiterfahrt ausschalten musste.",
+					"delay": 800
 				}
 			]
 		},
@@ -247,6 +281,10 @@
 				},
 				{
 					"name": "Aus einem Container wurden während eines Betriebshalts komische Geräusche wahrgenommen. Nach einer Überprüfung wurde aber nur Druckerzubehör gefunden.",
+					"delay": 1000
+				},
+				{
+					"name": "In einem Container wurden Seerobben transportiert, die vom Lokführer erst gefüttert werden mussten.",
 					"delay": 1000
 				}
 			]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -9175,6 +9175,148 @@
 				{ "name": "castor", "value": 10 }
 			],
 			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Ekol-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre den Ekol von %s nach %s.",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "KK", "XIT" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 39 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Ambrogio-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "KN", "XIMB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 33 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Walter-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV-Ganzzug von %s nach %s.",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "EWAN", "XUCU" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 39 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Pozan-Shuttle-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen Shuttle-KLV von %s nach %s.",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "🇳🇱Erp", "🇵🇱PWS" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 28 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Eiserner Rhein-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen altehrwürdigen KLV von %s nach %s.",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "🇳🇱Erp", "XIMB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 30 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Lovosice-Shuttle-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV von %s nach %s.",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "KRH", "XTLO" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 28 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Mars-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Keine Schokoriegel, sondern einen Intermodalzug bespannst du von Luxemburg bis an die Adria",
+				"Fahre diesen Güterzug pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "XLB", "XIT" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "containers", "value": 36 }
+			],
+			"stopsEverywhere": false
+		},
+		{
+			"group": 0,
+			"name": "Kohlezug von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Schaffe, Schaffe, Kohlezügle! - Bringe Importkohle vom Rotterdamer Hafen ins Ländle"
+			],
+			"objects": [
+				{
+					"stations": [ "🇳🇱Erp", "TP" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "coal", "value": 715 }
+			],
+			"stopsEverywhere": false
 		}
 	]
 }

--- a/Train.json
+++ b/Train.json
@@ -3602,26 +3602,6 @@
 			]
 		},
 		{
-			"id": 622,
-			"group": 2,
-			"name": "Alstom Coradia LINT 54",
-			"shortcut": "BR 622",
-			"speed": 140,
-			"weight": 98,
-			"force": 87,
-			"length": 54,
-			"drive": 2,
-			"reliability": 1,
-			"cost": 350000,
-			"maxConnectedUnits": 2,
-			"compatibleWith": [32],
-			"operationCosts": 70,
-			"exchangeTime": 60,
-			"capacity": [
-				{"name": "passengers", "value": 180}
-			]
-		},
-		{
 			"id": 32,
 			"group": 2,
 			"name": "Alstom Coradia LINT 81",
@@ -3632,8 +3612,7 @@
 			"length": 81,
 			"drive": 2,
 			"reliability": 1,
-			"cost": 500000,
-			"compatibleWith": [622],
+			"cost": 300000,
 			"maxConnectedUnits": 2,
 			"operationCosts": 70,
 			"exchangeTime": 60,
@@ -9411,6 +9390,23 @@
 			"cost": 100000,
 			"capacity": [
 				{"name": "containers", "value": 1}
+			]
+		},
+		{
+			"id": 3000,
+			"group": 1,
+			"service": 11,
+			"name": "Taschentragwagen T3000e",
+			"shortcut": "Sdggmrss",
+			"speed": 120,
+			"weight": 35,
+			"force": 0,
+			"length": 34,
+			"drive": 0,
+			"reliability": 1,
+			"cost": 175000,
+			"capacity": [
+				{"name": "containers", "value": 3}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -3602,6 +3602,26 @@
 			]
 		},
 		{
+			"id": 622,
+			"group": 2,
+			"name": "Alstom Coradia LINT 54",
+			"shortcut": "BR 622",
+			"speed": 140,
+			"weight": 98,
+			"force": 87,
+			"length": 54,
+			"drive": 2,
+			"reliability": 1,
+			"cost": 350000,
+			"maxConnectedUnits": 2,
+			"compatibleWith": [32],
+			"operationCosts": 70,
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 180}
+			]
+		},
+		{
 			"id": 32,
 			"group": 2,
 			"name": "Alstom Coradia LINT 81",
@@ -3612,8 +3632,9 @@
 			"length": 81,
 			"drive": 2,
 			"reliability": 1,
-			"cost": 300000,
-			"maxConnectedUnits": 3,
+			"cost": 500000,
+			"compatibleWith": [622],
+			"maxConnectedUnits": 2,
 			"operationCosts": 70,
 			"exchangeTime": 60,
 			"capacity": [


### PR DESCRIPTION
Ein paar Containergüterzüge (eigentlich KLVs) hinzugefügt, um den verfügbaren Pool an mitteleuropäischen Güterzugausschreibungen zu erhöhen.

Darunter sind:
 - 39 Container Köln - Trieste
 - 33 Container Neuss - Milano
 - 39 Container  Wanne-Eickel - Curticì
 - 28 Container Rotterdamm Europoorte - Poznan
 - 30 Container Rotterdamm Europoorte - Milano
 - 28 Container Rheinhausen - Lovosice
 - 36 Container Bettembourg - Trieste
 - 715t Kohle von Rotterdamm Europoorte - Plochingen

Zusätzlich: 
 - T3000e (175000 Plops, 3 Container)
 - Neue Verspätungsmeldungen