### PR TITLE
Lint 54, BR 219 & 229 hinzugefügt, kleinerer Fix am russischen Kiss 160

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -6204,6 +6204,32 @@
 			"operationCosts": 145
 		},
 		{
+			"id": 219,
+			"group": 0,
+			"name": "BR 219",
+			"speed": 120,
+			"weight": 99,
+			"force": 220,
+			"length": 20,
+			"drive": 2,
+			"reliability": 0.8,
+			"cost": 210000,
+			"operationCosts": 155
+		},
+		{
+			"id": 229,
+			"group": 0,
+			"name": "BR 229",
+			"speed": 140,
+			"weight": 116,
+			"force": 276,
+			"length": 20,
+			"drive": 2,
+			"reliability": 0.8,
+			"cost": 220000,
+			"operationCosts": 150
+		},
+		{
 			"id": 223,
 			"group": 0,
 			"name": "Eurorunner",

--- a/Train.json
+++ b/Train.json
@@ -3602,6 +3602,26 @@
 			]
 		},
 		{
+			"id": 622,
+			"group": 2,
+			"name": "Alstom Coradia LINT 54",
+			"shortcut": "BR 622",
+			"speed": 140,
+			"weight": 95,
+			"force": 87,
+			"length": 54,
+			"drive": 2,
+			"reliability": 1,
+			"cost": 350000,
+			"compatibleWith": [32],
+			"maxConnectedUnits": 2,
+			"operationCosts": 70,
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 172}
+			]
+		},
+		{
 			"id": 32,
 			"group": 2,
 			"name": "Alstom Coradia LINT 81",
@@ -3612,7 +3632,8 @@
 			"length": 81,
 			"drive": 2,
 			"reliability": 1,
-			"cost": 300000,
+			"cost": 400000,
+			"compatibleWith": [622],
 			"maxConnectedUnits": 2,
 			"operationCosts": 70,
 			"exchangeTime": 60,

--- a/Train.json
+++ b/Train.json
@@ -3283,7 +3283,7 @@
 			"cost": 900000,
 			"operationCosts": 70,
 			"maxConnectedUnits": 2,
-			"equipments": ["RU"],
+			"equipments": ["RU", "1520mm"],
 			"capacity": [
 				{"name": "passengers", "value": 842}
 			]


### PR DESCRIPTION
Hinzugefügt:
 - Lint 54 (622): Kuppelbar mit dem 620, 350000 Plops, 175 Passagiere
 - BR 219, 210000 Plops
 - BR 229, 220000 Plops

Geändert:
 - Lint 81 (620): Preis angehoben auf 400000, kuppelbar mit 622
 - Stadler KISS 160 1520mm: Hier fehlten die 1520mm als Equipment