### PR TITLE
Nerf von Doppelstock-Containerwagen

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -9651,8 +9651,7 @@
 			"length": 22,
 			"drive": 0,
 			"reliability": 1,
-			"cost": 130000,
-			"equipments": [ "US", "CA" ],
+			"cost": 260000,
 			"capacity": [
 				{"name": "containers", "value": 4}
 			]


### PR DESCRIPTION
preislich sind diese sonst auf dem europäischen Markt äußerst unfair.