### PR TITLE
Neue Cargo Trailer/Wechselbrücken hinzugefügt, um KLV und Containerzüge zu entflechten

### DIFF
--- a/Capacity.json
+++ b/Capacity.json
@@ -78,6 +78,13 @@
 			"needsPlatform": false,
 			"unitMass": 135,
 			"emoji": "☢️"
+		},
+		{
+			"idString": "trailers",
+			"name": "KLV-Trailer",
+			"needsPlatform": false,
+			"unitMass": 35,
+			"emoji": "📦"
 		}
 	]
 }

--- a/DelayModel.json
+++ b/DelayModel.json
@@ -344,6 +344,24 @@
 					"delay": 1000
 				}
 			]
+		},
+		{
+			"type": 2,
+			"capacity": "trailers",
+			"objects" : [
+				{
+					"name": "Ein Trailer war nicht genügend gesichtert und musste mit einem LKW hinterher gefahren werden.",
+					"delay": 1000
+				},
+				{
+					"name": "Die Alarmanlage eines Trailers ging los, und konnte erst durch Intervention der Bundespolizei und eines Technikers gestoppt werden.",
+					"delay": 1000
+				},
+				{
+					"name": "Die Disposition eines Logistikunternehmens hat festgestellt, dass der falsche Trailer verladen wurde, welcher schnell ausgetauscht werden musste.",
+					"delay": 1000
+				}
+			]
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -9551,7 +9551,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 39 }
+				{ "name": "trailers", "value": 28 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9568,7 +9568,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 33 }
+				{ "name": "trailers", "value": 26 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9586,7 +9586,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 39 }
+				{ "name": "trailers", "value": 28 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9604,7 +9604,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 28 }
+				{ "name": "trailers", "value": 24 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9622,7 +9622,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 30 }
+				{ "name": "trailers", "value": 26 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9640,7 +9640,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 28 }
+				{ "name": "trailers", "value": 26 }
 			],
 			"stopsEverywhere": false
 		},
@@ -9658,7 +9658,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "containers", "value": 36 }
+				{ "name": "trailers", "value": 28 }
 			],
 			"stopsEverywhere": false
 		},

--- a/Train.json
+++ b/Train.json
@@ -9601,7 +9601,24 @@
 			"reliability": 1,
 			"cost": 175000,
 			"capacity": [
-				{"name": "containers", "value": 3}
+				{"name": "trailers", "value": 2}
+			]
+		},
+		{
+			"id": 3734,
+			"group": 1,
+			"service": 11,
+			"name": "Taschentragwagen T3",
+			"shortcut": "Sdgmns 743",
+			"speed": 100,
+			"weight": 21,
+			"force": 0,
+			"length": 18,
+			"drive": 0,
+			"reliability": 1,
+			"cost": 175000,
+			"capacity": [
+				{"name": "trailers", "value": 1}
 			]
 		},
 		{

--- a/Train.json
+++ b/Train.json
@@ -9616,7 +9616,7 @@
 			"length": 18,
 			"drive": 0,
 			"reliability": 1,
-			"cost": 175000,
+			"cost": 150000,
 			"capacity": [
 				{"name": "trailers", "value": 1}
 			]


### PR DESCRIPTION
In den letzten Commits wurden sehr viele Containerzüge hinzugefügt, die teilweise in Ermangelung einer besseren Möglichkeit eigentlich KLV-Züge waren. Um den Markt zu diversifizieren und einen neuen Bereich hinzuzufügen, wird nun in diesem PR eine neue Cargo hinzugefügt.

Diese PR fügt hinzu:
 - Neue Capacity "Trailers"
 - Taschentragwagen T3 und T3000e (150'000 und 175'000 Plops)
 - auf die neue Cargo umgestellte KLV-Aufträge aus #822