### PR TITLE
VzG-Strecke 3512 hinzugefuegt und Route Nahe-Express korrigiert

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -42690,6 +42690,31 @@
 			]
 		},
 		{
+			"name": "Bahnstrecke Gau Algesheim–Bad Kreuznach",
+			"electrified": false,
+			"group": 0,
+			"maxSpeed": 120,
+			"twistingFactor": 0,
+			"neededEquipments": [
+				"DE"
+			],
+			"objects": [
+				{
+					"start": "SBKN",
+					"end": "FGHO",
+					"length": 8,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "FGHO",
+					"end": "FGAL",
+					"length": 11,
+					"twistingFactor": 0.35,
+					"maxSpeed": 100
+				}
+			]
+		},
+		{
 			"electrified": false,
 			"group": 0,
 			"maxSpeed": 100,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -2950,8 +2950,8 @@
 				"Der RE3 muss von %s nach %s gebracht werden. Die Strecke ist stark ausgelastet.",
 				"Bringe den Regional-Express der Linie 3 pünktlich von %s nach %s."
 			],
-			"stations": [ "FF", "FFLF", "FRUE", "FMZ", "FBGK", "SBKN", "SBMS", "SIDO", "SNK", "SSH" ],
-			"pathSuggestion": [ "FF", "FFLF", "FRUE", "FMB", "FMZ", "FBGK", "SBKN", "SBMS", "SIDO", "SNK", "SSH" ],
+			"stations": [ "FF", "FFLF", "FRUE", "FMZ", "FIL", "SBKN", "SBMS", "SSOB", "SKR", "SIDO", "SNK", "SSH" ],
+			"pathSuggestion": [ "FF", "FFLF", "FRUE", "FMB", "FMZ", "FIL", "SBKN", "SBMS", "SSOB", "SKR", "SIDO", "SNK", "SSH" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]


### PR DESCRIPTION
Bahnstrecke Gau Algesheim–Bad Kreuznach
SBKN - FGHO - FGAL

https://de.wikipedia.org/wiki/Bahnstrecke_Gau_Algesheim%E2%80%93Bad_Kreuznach

Nahe-Express RE3
http://osmtrainroutes.bplaced.net/index.php?id=418586&service=regional&route=train&train=LINT41