### PR TITLE
Fixed typo in Freizeitpark task

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -5266,7 +5266,7 @@
 			"descriptions": [
 				"In %s wurde es zu langweilig. Fahre nach %s",
 				"Nach dem Besuch in %s steht der nächste Besuch in %s an",
-				"Ein Freizeitpark reicht nicht. Fahre zum nächsten nach %s"
+				"Ein Freizeitpark reicht nicht. Fahre zum nächsten nach %2$s"
 			],
 			"objects": [
 				{


### PR DESCRIPTION
Fixed the description of "Freizeitpark Sonderzug" - changed %s to %2$s in line 5269