### PR TITLE
Add Station Ludwigshafen (Rhein) Hbf and Paths

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -1006,9 +1006,16 @@
 			"objects": [
 				{
 					"start": "RM",
+					"end": "RL",
+					"length": 3,
+					"twistingFactor": 0.29,
+					"maxSpeed": 80
+				},
+				{
+					"start": "RL",
 					"end": "RFT",
-					"twistingFactor": 0.35,
-					"length": 13,
+					"length": 10,
+					"twistingFactor": 0.26,
 					"maxSpeed": 140
 				},
 				{
@@ -1804,10 +1811,17 @@
 				},
 				{
 					"start": "RLUR",
-					"end": "RM",
-					"length": 6,
-					"twistingFactor": 0.3,
+					"end": "RL",
+					"length": 3,
+					"twistingFactor": 0,
 					"maxSpeed": 130
+				},
+				{
+					"start": "RL",
+					"end": "RM",
+					"length": 3,
+					"twistingFactor": 0.29,
+					"maxSpeed": 80
 				}
 			]
 		},

--- a/Station.json
+++ b/Station.json
@@ -43036,6 +43036,16 @@
 			"proj": 3
 		},
 		{
+			"name": "Ludwigshafen (Rhein) Hbf",
+			"ril100": "RL",
+			"group": 0,
+			"x": 262,
+			"y": 379,
+			"platformLength": 421,
+			"platforms": 10,
+			"proj": 3
+		},
+		{
 			"name": "Lisewo",
 			"ril100": "🇵🇱O9927825615",
 			"group": 5,


### PR DESCRIPTION
@marhei: Das Pfadsegment zwischen RL und RM gibt es jetzt zweimal ("Realitätstreu" weils ja auch zwei Strecken sind), aber evtl ist das doof fürs Routing und so?