### PR TITLE
Hinzufügen und Anpassung der RB 60 zwischen Eberswalde und Frankfurt (Oder)

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -49124,7 +49124,7 @@
 			"ril100": "BWRZ",
 			"x": 1028,
 			"y": -156,
-			"platformLength": 95,
+			"platformLength": 104,
 			"platforms": 2,
 			"proj": 3
 		},

--- a/Station.json
+++ b/Station.json
@@ -49180,7 +49180,7 @@
 			"ril100": "WFBG",
 			"x": 1003,
 			"y": -171,
-			"platformLength": 60,
+			"platformLength": 62,
 			"platforms": 1,
 			"proj": 3
 		},

--- a/Station.json
+++ b/Station.json
@@ -49089,7 +49089,7 @@
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Seelow (Mark)",
 			"ril100": "BSLO",
 			"x": 1063,

--- a/Station.json
+++ b/Station.json
@@ -49079,13 +49079,11 @@
 			"proj": 3
 		},
 		{
-			"group": 2,
+			"group": 3,
 			"name": "Schönfließ Dorf",
 			"ril100": "BSOE",
 			"x": 1075,
 			"y": -111,
-			"platformLength": 69,
-			"platforms": 1,
 			"proj": 3
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -49134,7 +49134,7 @@
 			"ril100": "BART",
 			"x": 1020,
 			"y": -164,
-			"platformLength": 60,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},

--- a/Station.json
+++ b/Station.json
@@ -49134,7 +49134,7 @@
 			"ril100": "BART",
 			"x": 1020,
 			"y": -164,
-			"platformLength": 50,
+			"platformLength": 60,
 			"platforms": 1,
 			"proj": 3
 		},

--- a/Station.json
+++ b/Station.json
@@ -49094,8 +49094,8 @@
 			"ril100": "BSLO",
 			"x": 1063,
 			"y": -127,
-			"platformLength": 95,
-			"platforms": 1,
+			"platformLength": 105,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -49104,8 +49104,8 @@
 			"ril100": "BLTS",
 			"x": 1057,
 			"y": -142,
-			"platformLength": 60,
-			"platforms": 2,
+			"platformLength": 105,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -49114,7 +49114,7 @@
 			"ril100": "BNTB",
 			"x": 1041,
 			"y": -149,
-			"platformLength": 102,
+			"platformLength": 105,
 			"platforms": 2,
 			"proj": 3
 		},

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -4654,7 +4654,7 @@
 					"stations": [ "BFP", "BMR", "BSB", "BLNG", "BSTW", "BKW" ]
 				},
 				{
-					"stations": [ "WE", "WNW", "WFW", "BWRZ", "BNTB", "BLTS", "BLSO", "BFP"]
+					"stations": [ "WE", "WNW", "WFW", "BWRZ", "BNTB", "BLTS", "BSLO", "BFP"]
 				}
 			],
 			"stopsEverywhere": true,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -4649,7 +4649,15 @@
 			"descriptions": [
 				"Bringe den Zug über Brandenburgische Nebenstrecken von %s nach %s."
 			],
-			"stations": [ "BFP", "BMR", "BSB", "BLNG", "BSTW", "BKW" ],
+			"objects": [
+				{
+					"stations": [ "BFP", "BMR", "BSB", "BLNG", "BSTW", "BKW" ]
+				},
+				{
+					"stations": [ "WE", "WNW", "WFW", "BWRZ", "BNTB", "BLTS", "BLSO", "BFP"]
+				}
+			],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]


### PR DESCRIPTION
Stationen an der Strecke geändert (Bahnsteiglänge, Anzahl an Gleisen mit Bahnsteig, Schönfließ Dorf ohne Halt)
Verbindung als Auftrag hinzugefügt