### PR TITLE
Kleinere Anpassung Knoten Saarbrücken

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -1469,20 +1469,14 @@
 					"end": "PQSU",
 					"twistingFactor": 0.2,
 					"length": 2,
-					"maxSpeed": 30,
-					"neededEquipments": [
-						"bostrab"
-					]
+					"maxSpeed": 30
 				},
 				{
 					"start": "PQSU",
 					"end": "SSH",
 					"twistingFactor": 0.2,
 					"length": 2,
-					"maxSpeed": 25,
-					"neededEquipments": [
-						"bostrab"
-					]
+					"maxSpeed": 25
 				},
 				{
 					"start": "SSH",


### PR DESCRIPTION
Nach dem Hinzufügen des Task für TER Saarbrücken - Strasbourg ist mir aufgefallen, dass der gar nicht durchführbar ist, weil der Abschnitt SSH - SBA aktuell nur über die Stadtbahn per BOStrab existiert.

Hab daher die Strecke SSH - SSO - SBA mal hinzugefügt. Damit es einigermaßen übersichtlich bleibt, ein paar Koordinaten leicht verschoben und SSO mit SSU zusammengefasst.

Außerdem die Tasks zwischen SKL - SSO entsprechend angepasst,, sodass hoffentlich nix kaputt geht.