### PR TITLE
Missing stations on existing swedish mainlines

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -70582,10 +70582,24 @@
 				},
 				{
 					"start": "XVAS",
-					"end": "XVFY",
-					"length": 55,
+					"end": "🇸🇪O270883345",
+					"length": 20,
 					"maxSpeed": 200,
-					"twistingFactor": 0.39
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇸🇪O270883345",
+					"end": "XVHE",
+					"length": 13,
+					"maxSpeed": 200,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "XVHE",
+					"end": "XVFY",
+					"length": 20,
+					"maxSpeed": 200,
+					"twistingFactor": 0.12
 				},
 				{
 					"start": "XVFY",
@@ -70603,10 +70617,31 @@
 				},
 				{
 					"start": "XVST",
-					"end": "XVLX",
-					"length": 100,
+					"end": "XVSVD",
+					"length": 15,
 					"maxSpeed": 200,
-					"twistingFactor": 0.18
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "XVSVD",
+					"end": "XVTB",
+					"length": 38,
+					"maxSpeed": 200,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "XVTB",
+					"end": "XVGJ",
+					"length": 22,
+					"maxSpeed": 200,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "XVGJ",
+					"end": "XVLX",
+					"length": 23,
+					"maxSpeed": 200,
+					"twistingFactor": 0.21
 				},
 				{
 					"start": "XVLX",
@@ -70638,10 +70673,24 @@
 				},
 				{
 					"start": "XVFN",
-					"end": "🇸🇪MÖ",
-					"length": 51,
+					"end": "🇸🇪O365743788",
+					"length": 25,
 					"maxSpeed": 180,
-					"twistingFactor": 0.5
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇸🇪O365743788",
+					"end": "XVGN",
+					"length": 18,
+					"maxSpeed": 180,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "XVGN",
+					"end": "🇸🇪MÖ",
+					"length": 6,
+					"maxSpeed": 180,
+					"twistingFactor": 0.19
 				},
 				{
 					"start": "🇸🇪MÖ",

--- a/Path.json
+++ b/Path.json
@@ -68972,10 +68972,17 @@
 				},
 				{
 					"start": "XVHL",
+					"end": "XVSNN",
+					"length": 2,
+					"maxSpeed": 130,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "XVSNN",
 					"end": "XVFA",
-					"length": 43,
+					"length": 39,
 					"maxSpeed": 200,
-					"twistingFactor": 0.37
+					"twistingFactor": 0.26
 				},
 				{
 					"start": "XVFA",
@@ -70652,10 +70659,17 @@
 				},
 				{
 					"start": "XVHA",
-					"end": "XVVI",
-					"length": 45,
+					"end": "🇸🇪O26793968",
+					"length": 13,
 					"maxSpeed": 200,
-					"twistingFactor": 0.32
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇸🇪O26793968",
+					"end": "XVVI",
+					"length": 30,
+					"maxSpeed": 200,
+					"twistingFactor": 0.01
 				},
 				{
 					"start": "XVVI",
@@ -70977,9 +70991,16 @@
 				},
 				{
 					"start": "XVK",
-					"end": "XVNC",
-					"length": 49,
+					"end": "🇸🇪O666421332",
+					"length": 25,
 					"maxSpeed": 200,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "🇸🇪O666421332",
+					"end": "XVNC",
+					"length": 22,
+					"maxSpeed": 180,
 					"twistingFactor": 0.17
 				}
 			]

--- a/Station.json
+++ b/Station.json
@@ -75886,6 +75886,14 @@
 			"proj": 3
 		},
 		{
+			"name": "Sannarp",
+			"ril100": "XVSNN",
+			"group": 4,
+			"x": 850,
+			"y": -801,
+			"proj": 3
+		},
+		{
 			"name": "Falkenberg (SE)",
 			"ril100": "XVFA",
 			"group": 2,
@@ -76117,6 +76125,14 @@
 			"proj": 3
 		},
 		{
+			"name": "Pålsboda",
+			"ril100": "🇸🇪O26793968",
+			"group": 6,
+			"x": 1152,
+			"y": -1181,
+			"proj": 3
+		},
+		{
 			"name": "Vingåker",
 			"ril100": "XVVI",
 			"group": 2,
@@ -76134,6 +76150,14 @@
 			"y": -1169,
 			"platformLength": 365,
 			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Simonstorp",
+			"ril100": "🇸🇪O666421332",
+			"group": 6,
+			"x": 1257,
+			"y": -1137,
 			"proj": 3
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -75976,6 +75976,26 @@
 			"proj": 3
 		},
 		{
+			"name": "Vårgårda",
+			"ril100": "🇸🇪O270883345",
+			"group": 2,
+			"x": 835,
+			"y": -1017,
+			"platformLength": 237,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Herrljunga",
+			"ril100": "XVHE",
+			"group": 1,
+			"x": 862,
+			"y": -1024,
+			"platformLength": 367,
+			"platforms": 6,
+			"proj": 3
+		},
+		{
 			"name": "Floby",
 			"ril100": "XVFY",
 			"group": 2,
@@ -76047,6 +76067,36 @@
 			"proj": 3
 		},
 		{
+			"name": "Skövde",
+			"ril100": "XVSVD",
+			"group": 2,
+			"x": 967,
+			"y": -1074,
+			"platformLength": 390,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Töreboda",
+			"ril100": "XVTB",
+			"group": 5,
+			"x": 1001,
+			"y": -1124,
+			"platformLength": 298,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Gardsjö",
+			"ril100": "XVGJ",
+			"group": 2,
+			"x": 1026,
+			"y": -1150,
+			"platformLength":61 ,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
 			"name": "Laxå",
 			"ril100": "XVLX",
 			"group": 2,
@@ -76094,6 +76144,24 @@
 			"y": -1179,
 			"platformLength": 350,
 			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Stjärnhov",
+			"ril100": "🇸🇪O365743788",
+			"group": 6,
+			"x": 1364,
+			"y": -1183,
+			"proj": 3
+		},
+		{
+			"name": "Gnesta",
+			"ril100": "XVGN",
+			"group": 2,
+			"x": 1402,
+			"y": -1178,
+			"platformLength": 175,
+			"platforms": 2,
 			"proj": 3
 		},
 		{


### PR DESCRIPTION
Ein paar fehlende Stationen/Wegpunkte auf den existierenden Linien in Schweden hinzugefügt.
Abzweigende Strecken sollten damit einfacher sein, der Score verbessert sich dadurch auch etwas.