### PR TITLE
Update Python version to 3.13

### DIFF
--- a/.github/workflows/add_path_suggestions.yml
+++ b/.github/workflows/add_path_suggestions.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install requirements
         run: python -m pip install -r tools/requirements.txt
       - name: Project coordinates

--- a/.github/workflows/check_content.yml
+++ b/.github/workflows/check_content.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install requirements
         run: python -m pip install -r tools/requirements.txt
       - name: Check contents

--- a/.github/workflows/create_map.yml
+++ b/.github/workflows/create_map.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install matplotlib
         run: python -m pip install -r tools/requirements.txt
       - name: Render map

--- a/.github/workflows/project_coordinates.yml
+++ b/.github/workflows/project_coordinates.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install requirements
         run: python -m pip install -r tools/requirements.txt
       - name: Project coordinates


### PR DESCRIPTION
Die Tools sind schon auf aktuelle Python-Versionen ausgelegt, die GitHub Actions haben aber bisher noch mit Python 3.9 gearbeitet (was aber eh nur noch bis Oktober mit Sicherheitsupdates versorgt wird).