### PR TITLE
added more KLV tasks

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -10221,6 +10221,9 @@
 			"objects": [
 				{
 					"stations": [ "XLB", "XIT" ]
+				},
+				{
+					"station": ["XLB", "XQHA"]
 				}
 			],
 			"neededCapacity": [
@@ -10602,6 +10605,108 @@
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
+		},{
+			"group": 0,
+			"name": "DSV-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "XVK", "XIMB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 33 }
+			],
+			"stopsEverywhere": false
+		},{
+			"group": 0,
+			"name": "Samskip-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "XVK", "KKR" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 33 }
+			],
+			"stopsEverywhere": false
+		},{
+			"group": 0,
+			"name": "Arcese-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "XIVP", "XTOH" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 33 }
+			],
+			"stopsEverywhere": false
+		},{
+			"group": 0,
+			"name": "Pimk-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s.",
+				"Fahre diesen KLV queer durch Südosteuropa."
+			],
+			"objects": [
+				{
+					"stations": [ "XWPL", "NN" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 34 }
+			],
+			"stopsEverywhere": false
+		},{
+			"group": 0,
+			"name": "Winner-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s.",
+				"Nur echte Gewinner fahren von %s nach %s."
+			],
+			"objects": [
+				{
+					"stations": [ "KW", "XIVP" ]
+				},
+				{
+					"stations": [ "KW", "XIMB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 33 }
+			],
+			"stopsEverywhere": false
+		},{
+			"group": 0,
+			"name": "Große-Vehne-KLV von %s nach %s",
+			"service": 11,
+			"descriptions": [
+				"Fahre diesen KLV pünktlich von %s nach %s.",
+				"Fahre diese Arterie des europäischen Güterverkehrs von %s nach %s"
+			],
+			"objects": [
+				{
+					"stations": [ "TS", "HB" ]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "trailers", "value": 33 }
+			],
+			"stopsEverywhere": false
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -10704,7 +10704,7 @@
 				}
 			],
 			"neededCapacity": [
-				{ "name": "trailers", "value": 33 }
+				{ "name": "trailers", "value": 30 }
 			],
 			"stopsEverywhere": false
 		}


### PR DESCRIPTION
Neue KLV Tasks und Alternativrouten für bestehende KLV.

+:
 - 33 Trailer Katrineholm - Milan (DSV)
 - 33 Trailer Katrineholm - Krefeld (Samskip)
 - 33 Trailer Verona - Ostrava (Arcese)
 - 34 Trailer Bettembourg - Halkali (Mars)
 - 34 Trailer Plovdiv - Nürnberg (Pimk Rail)
 - 30 Trailer Stuttgart - Bremen (Große-Vehne)
 - 33 Trailer Wuppertal - Verona (Winner)
 - 33 Trailer Wuppertal - Milan (Winner)