### PR TITLE
Stadler Eurodual hat Zulassung für Norwegen

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -5944,7 +5944,7 @@
 			"reliability": 1,
 			"cost": 600000,
 			"operationCosts": 130,
-			"equipments": [ "FR", "ETCS", "AT", "DE", "TR", "ES", "NL", "BE", "CH", "SE", "IT", "LU", "GB" ]
+			"equipments": [ "FR", "ETCS", "AT", "DE", "TR", "ES", "NL", "BE", "CH", "SE", "IT", "LU", "GB", "NO" ]
 		},
 		{
 			"id": 54362,


### PR DESCRIPTION
[![](https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/CN_159_003_Oter%C3%A5ga_-_Valnesfjord.jpg/1920px-CN_159_003_Oter%C3%A5ga_-_Valnesfjord.jpg)](https://de.wikipedia.org/wiki/CargoNet#/media/Datei:CN_159_003_Oter%C3%A5ga_-_Valnesfjord.jpg)

Quelle: https://web.archive.org/web/20201126201443/https://bahnblogstelle.net/2020/11/09/eurodual-lokomotive-fuer-den-einsatz-in-norwegen-und-schweden-zugelassen/