### PR TITLE
Traxx F140 AC2 läuft als CE 119 in 🇳🇴 Norwegen

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -6048,7 +6048,7 @@
 			"reliability": 1,
 			"cost": 500000,
 			"operationCosts": 80,
-			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "DE", "IT", "HU"]
+			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "NO", "DE", "IT", "HU"]
 		},
 		{
 			"id": 189,


### PR DESCRIPTION
Die Traxx F140 AC2 läuft als CE 119 für CargoNet bzw. als 185 im Leasing.

[![](https://bahnbilder.ch/photos/xlarge/43944.jpg)](https://bahnbilder.ch/43944)
[![](https://www.bahnbilder.de/bilder/die-loks-11906-11905-des-296520.jpg)](https://www.bahnbilder.de/bild/norwegen~e-loks~0-119-traxx-ac2/296520/die-loks-11906-und-11905-des.html)

Quellen:

* https://web.archive.org/web/20160103123929/http://www.tu.no/industri/motor/2008/10/31/bombardert-jernbanestolthet
* https://www.scanditrain.de/n_el/el19/0startseite_special.html
* https://en.wikipedia.org/wiki/Alstom_Traxx#Operators_and_leasing_companies