### PR TITLE
EC Hamburg-Kopenhagen geändert

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -1860,7 +1860,7 @@
 			],
 			"neededCapacity": [
 			{ "name": "passengers" }
-			]
+			],
 			"stations": [ "XDKH", "XDRI", "XDOD", "XDKO", "XDPA", "ASW", "AH" ],
 			"pathSuggestion": [ "XDKH", "🇩🇰VB", "XDRI", "XDOD", "XDMF", "XTDA", "XDKO", "XDLU", "XDTI", "XDPA", "AF", "AJ", "ASW", "AR", "AN", "AEL", "AH" ]
 		},


### PR DESCRIPTION
ICE gestrichen, EC von Berlin - Kopenhagen auf Hamburg - Kopenhagen gekürzt, Halte auf Realität angepasst, weitere Punkte für PathSuggestion hinzugefügt