### PR TITLE
Update Schweizer Mittelland V2.0

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -71905,6 +71905,7 @@
 			]
 		},
 		{
+			"name": "Stammstrecke",
 			"electrified": true,
 			"group": 0,
 			"neededEquipments": [
@@ -71912,33 +71913,42 @@
 			],
 			"objects": [
 				{
-					"start": "XSZG",
+					"start": "🇨🇭RTR",
 					"end": "XSLT",
-					"length": 19,
-					"maxSpeed": 200,
+					"length": 13,
+					"maxSpeed": 125,
 					"twistingFactor": 0.2
 				},
 				{
 					"start": "XSLT",
 					"end": "XSHZ",
 					"length": 7,
-					"maxSpeed": 200,
+					"maxSpeed": 140,
 					"twistingFactor": 0.2
 				},
 				{
 					"start": "XSHZ",
 					"end": "🇨🇭BDF",
 					"length": 16,
-					"maxSpeed": 140,
+					"maxSpeed": 125,
 					"twistingFactor": 0.26
 				},
 				{
 					"start": "🇨🇭BDF",
 					"end": "XSBE",
-					"length": 21,
+					"length": 22,
 					"maxSpeed": 140,
 					"twistingFactor": 0.2
-				},
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
 				{
 					"start": "XSBE",
 					"end": "XSFM",
@@ -72019,18 +72029,6 @@
 			]
 		},
 		{
-			"start": "XSLT",
-			"end": "XSBE",
-			"neededEquipments": [
-				"CH"
-			],
-			"electrified": true,
-			"group": 0,
-			"length": 43,
-			"maxSpeed": 200,
-			"twistingFactor": 0.2
-		},
-		{
 			"group": 0,
 			"maxSpeed": 140,
 			"twistingFactor": 0,
@@ -72066,17 +72064,34 @@
 		{
 			"electrified": true,
 			"group": 0,
+			"name": "Gäubahn",
 			"neededEquipments": [
 				"CH"
 			],
 			"objects": [
 				{
-					"start": "XSLT",
-					"end": "XSSO",
-					"length": 19,
-					"maxSpeed": 200,
-					"twistingFactor": 0.15
+					"start": "XSOL",
+					"end": "🇨🇭OEN",
+					"length": 17,
+					"maxSpeed": 130,
+					"twistingFactor": 0.20
 				},
+				{
+					"start": "🇨🇭OEN",
+					"end": "XSSO",
+					"length": 17,
+					"maxSpeed": 130,
+					"twistingFactor": 0.12
+				}
+			]
+		},
+		{			
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
 				{
 					"start": "XSSO",
 					"end": "XSGRN",
@@ -79928,6 +79943,95 @@
 					"end": "TSHL",
 					"length": 12,
 					"maxSpeed": 120
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 1,
+			"name": "Oensingen-Balsthal-Bahn",
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"start": "🇨🇭OEN",
+					"end": "🇨🇭KLUS",
+					"length": 2,
+					"maxSpeed": 40,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇨🇭KLUS",
+					"end": "🇨🇭THBU",
+					"length": 1,
+					"maxSpeed": 40,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "🇨🇭THBU",
+					"end": "🇨🇭BTH",
+					"length": 1,
+					"maxSpeed": 40,
+					"twistingFactor": 0.4
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 2,
+			"name": "Neubaustrecke",
+			"neededEquipments": [
+				"CH",
+				"ETCS"
+			],
+			"objects": [
+				{
+					"start": "🇨🇭RTR",
+					"end": "🇨🇭WANZ",
+					"length": 20,
+					"maxSpeed": 200,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "🇨🇭WANZ",
+					"end": "XSBE",
+					"length": 36,
+					"maxSpeed": 200,
+					"twistingFactor": 0.12
+				},
+				{
+					"name": "Ausbaustrecke",
+					"start": "🇨🇭WANZ",
+					"end": "XSSO",
+					"length": 9,
+					"maxSpeed": 200,
+					"twistingFactor": 0.12
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"name": "Bornlinie",
+					"start": "🇨🇭RTR",
+					"end": "XSOL",
+					"length": 6,
+					"maxSpeed": 140,
+					"twistingFactor": 0.12
+				},
+				{
+					"name": "Kriegsschlaufe",
+					"start": "🇨🇭RTR",
+					"end": "XSZG",
+					"length": 7,
+					"maxSpeed": 140,
+					"twistingFactor": 0.20
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -75501,8 +75501,8 @@
 			"name": "Langenthal",
 			"ril100": "XSLT",
 			"group": 2,
-			"x": 166,
-			"y": 756,
+			"x": 167,
+			"y": 761,
 			"platformLength": 402,
 			"platforms": 3,
 			"proj": 3
@@ -77140,9 +77140,9 @@
 			"ril100": "XSN",
 			"group": 2,
 			"x": 193,
-			"y": 760,
+			"y": 766,
 			"platformLength": 200,
-			"platforms": 3,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -77152,7 +77152,7 @@
 			"x": 248,
 			"y": 780,
 			"platformLength": 221,
-			"platforms": 1,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -77182,7 +77182,7 @@
 			"x": 144,
 			"y": 785,
 			"platformLength": 221,
-			"platforms": 2,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -77571,8 +77571,8 @@
 			"name": "Solothurn",
 			"ril100": "XSSO",
 			"group": 2,
-			"x": 132,
-			"y": 758,
+			"x": 135,
+			"y": 764,
 			"platformLength": 401,
 			"platforms": 3,
 			"proj": 3
@@ -89471,6 +89471,64 @@
 			"group": 3,
 			"x": 477,
 			"y": 483,
+			"proj": 3
+		},
+		{
+			"name": "Rothrist",
+			"ril100": "🇨🇭RTR",
+			"group": 2,
+			"x": 179,
+			"y": 744,
+			"platformLength": 222,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Oensingen",
+			"ril100": "🇨🇭OEN",
+			"group": 2,
+			"x": 157,
+			"y": 748,
+			"platformLength": 421,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Klus",
+			"ril100": "🇨🇭KLUS",
+			"group": 5,
+			"x": 155,
+			"y": 744,
+			"platformLength": 100,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Thalbrücke",
+			"ril100": "🇨🇭THBU",
+			"group": 5,
+			"x": 154,
+			"y": 743,
+			"platformLength": 100,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Balsthal",
+			"ril100": "🇨🇭BTH",
+			"group": 2,
+			"x": 155,
+			"y": 742,
+			"platformLength": 100,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Wanzwil",
+			"ril100": "🇨🇭WANZ",
+			"group": 4,
+			"x": 159,
+			"y": 762,
 			"proj": 3
 		}
 	]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -27,7 +27,7 @@
 				},
 				{
 					"stations": [ "XSIO", "XSSP", "XSTH", "XSBE", "XSOL", "XSB", "RB", "RF", "RO", "RK", "RM", "FF", "FH", "FFU", "FKW", "HG", "HH", "HWOB", "BL", "BHF" ],
-					"pathSuggestion": [ "XSIO", "XSSP", "XSTH", "XSBE", "XSLT", "XSZG", "XSOL", "XSB", "RB", "RML", "RF", "RO", "RAP", "RK", "RGN", "RSAB", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FKW", "HG", "HH", "HLER", "HWOB", "LS", "BSPD", "BL", "BHF" ]
+					"pathSuggestion": [ "XSIO", "XSSP", "XSTH", "XSBE", "🇨🇭RTR", "XSOL", "XSB", "RB", "RML", "RF", "RO", "RAP", "RK", "RGN", "RSAB", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FKW", "HG", "HH", "HLER", "HWOB", "LS", "BSPD", "BL", "BHF" ]
 				},
 				{
 					"stations": [ "TS", "RM", "FFLF", "FF", "FKW", "HG", "HH", "AH" ],
@@ -326,7 +326,7 @@
 		{
 			"name": "Voralpen-Express von %s nach %s",
 			"descriptions": [
-				"Bringe den Interregio von %s nach %s.",
+				"Bringe den InterRegio von %s nach %s.",
 				"Bring die Fahrgäste in dem IR pünktlich nach %2$s.",
 				"Fahre den IR störungsfrei nach %2$s.",
 				"Bring den Voralpen-Express von %s nach %s."
@@ -341,7 +341,7 @@
 		{
 			"name": "IC von %s nach %s",
 			"descriptions": [
-				"Bringe den Intercity von %s nach %s.",
+				"Bringe den InterCity von %s nach %s.",
 				"Bring die Fahrgäste in dem IC pünktlich nach %2$s.",
 				"Fahre den IC störungsfrei nach %2$s."
 			],
@@ -353,7 +353,7 @@
 			"objects": [
 				{
 					"stations": [ "XSGE", "XSMG", "XSY", "XSNC", "XSBL", "XSSO", "XSOL", "XSA", "XSZH", "XSWT", "XSSG", "XSRS" ],
-					"pathSuggestion": [ "XSGE", "XSMG", "🇨🇭COS", "XSY", "XSNC", "XSBL", "XSGRN", "XSSO", "XSLT", "XSZG", "XSOL", "XSA", "XSKS", "XSZH", "XSZO", "XSWT", "XSSG", "XSRS" ]
+					"pathSuggestion": [ "XSGE", "XSMG", "🇨🇭COS", "XSY", "XSNC", "XSBL", "XSGRN", "XSSO", "🇨🇭RTR", "XSOL", "XSA", "XSKS", "XSZH", "XSZO", "XSWT", "XSSG", "XSRS" ]
 				},
 				{
 					"stations": [ "XSB", "XSOL", "XSLU", "XSAG", "XSBZ", "XSL" ],
@@ -361,7 +361,7 @@
 				},
 				{
 					"stations": [ "XSB", "XSOL", "XSBE", "XSTH", "XSSP", "XSVI", "XSBG" ],
-					"pathSuggestion": [ "XSB", "XSOL", "XSZG", "XSLT", "XSBE", "XSTH", "XSSP", "XSVI", "XSBG" ]
+					"pathSuggestion": [ "XSB", "XSOL", "🇨🇭RTR", "XSBE", "XSTH", "XSSP", "XSVI", "XSBG" ]
 				},
 				{
 					"stations": [ "XSB", "XSZH", "XSSR", "XSLQ", "XSC" ],
@@ -372,12 +372,12 @@
 					"pathSuggestion": [ "XSZH", "XSTW", "XSZU", "XSAG", "XSADF", "XSBC", "XSBZ", "XSL" ]
 				},
 				{
-					"pathSuggestion": [ "XSLA", "🇨🇭PUI", "XSF", "XSBE", "XSLT", "XSZG", "XSOL", "XSKS", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG" ],
+					"pathSuggestion": [ "XSLA", "🇨🇭PUI", "XSF", "XSBE", "🇨🇭RTR", "XSOL", "XSKS", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG" ],
 					"stations": [ "XSLA", "XSF", "XSBE", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG" ]
 				},
 				{
 					"stations": [ "XSZH", "XSBE", "XSTH", "XSSP", "XSIO" ],
-					"pathSuggestion": [ "XSZH", "XSKS", "XSLB", "XSOL", "XSZG", "XSLT", "XSBE", "XSTH", "XSSP", "XSIO" ]
+					"pathSuggestion": [ "XSZH", "XSKS", "XSLB", "XSOL", "🇨🇭RTR", "XSBE", "XSTH", "XSSP", "XSIO" ]
 				}
 			]
 		},
@@ -2282,7 +2282,7 @@
 				},
 				{
 					"stations": [ "XSZH", "XSBE", "XSLA", "XSGE", "XFLPD", "XFAVV", "XFNB", "XFPE", "XEB" ],
-					"pathSuggestion": [ "XSZH", "XSKS", "XSOL", "XSZG", "XSLT", "XSBE", "🇨🇭PUI", "XSLA", "XSMG", "XSGE", "XFCZ", "XFLPD", "XFVI", "🇫🇷TAI", "XFVCV", "🇫🇷LIV", "🇫🇷PRL", "🇫🇷BLN", "XFOR", "🇫🇷BDR", "XFAVV", "🇫🇷77539", "🇫🇷NMS", "🇫🇷VLM", "XFNB", "XFPE", "XEB" ]
+					"pathSuggestion": [ "XSZH", "XSKS", "XSOL", "🇨🇭RTR", "XSLT", "🇨🇭BDF", "XSBE", "🇨🇭PUI", "XSLA", "XSMG", "XSGE", "XFCZ", "XFLPD", "XFVI", "🇫🇷TAI", "XFVCV", "🇫🇷LIV", "🇫🇷PRL", "🇫🇷BLN", "XFOR", "🇫🇷BDR", "XFAVV", "🇫🇷77539", "🇫🇷NMS", "🇫🇷VLM", "XFNB", "XFPE", "XEB" ]
 				},
 				{
 					"stations": [ "MH", "MRO", "XASB", "XAWL", "XIVP", "XIVNS" ],
@@ -5895,7 +5895,7 @@
 				},
 				{
 					"stations": [ "🇨🇭SE", "XSSN" ],
-					"pathSuggestion": [ "🇨🇭SE", "XSLU", "XSZG", "XSLT" , "XSHZ", "XSBE", "XSSP", "XSFR", "XSBG", "XSLE", "XSSN" ]
+					"pathSuggestion": [ "🇨🇭SE", "XSLU", "XSZG", "🇨🇭RTR", "XSLT" , "🇨🇭BDF", "XSBE", "XSSP", "XSFR", "XSKA", "XSGO", "XSBG", "XSLE", "XSSN" ]
 				}
 			],
 			"neededCapacity": [
@@ -7041,7 +7041,7 @@
 				},
 				{
 					"stations": [ "XFSTG", "XSBE", "XIMB", "XIVP", "XAWW", "XMBK", "XJBC", "ZAS", "XGT", "XWS", "XQIS" ],
-					"pathSuggestion": [ "XFSTG", "XFMV", "RML", "RB", "XSB", "XSOL", "XSZG", "XSLT", "XSBE", "XSSP", "XSVI", "XIR", "XIMB", "XIVP", "XIFF", "XAI", "🇦🇹Fw Z2", "XAWL", "MRO", "MTS", "MFL", "XASB", "XASF", "XAAT", "XAWE", "XAL", "XAWW", "XMBK", "XJSP", "XJBC", "XJBR", "XJNI", "XJLE", "ZAS", "XGT", "XGPM", "XWPR", "XWS", "🇧🇬14000", "XWSV", "XQIS" ]
+					"pathSuggestion": [ "XFSTG", "XFMV", "RML", "RB", "XSB", "XSOL", "🇨🇭RTR", "XSLT", "🇨🇭BDF", "XSBE", "XSSP", "XSVI", "XIR", "XIMB", "XIVP", "XIFF", "XAI", "🇦🇹Fw Z2", "XAWL", "MRO", "MTS", "MFL", "XASB", "XASF", "XAAT", "XAWE", "XAL", "XAWW", "XMBK", "XJSP", "XJBC", "XJBR", "XJNI", "XJLE", "ZAS", "XGT", "XGPM", "XWPR", "XWS", "🇧🇬14000", "XWSV", "XQIS" ]
 				}
 			],
 			"neededCapacity": [
@@ -8974,13 +8974,10 @@
 					"stations": [ "XSBL", "XSGRN", "XSDE" ]
 				},
 				{
-					"stations": [ "XSOL", "XSZG", "XSLT", "XSGRN", "XSBL" ]
-				},
-				{
 					"stations": [ "XSBL", "XSBE", "XSSP", "XSIO" ]
 				},
 				{
-					"stations": [ "XSOL", "XSZG", "XSLT", "XSHZ", "XSBE" ]
+					"stations": [ "XSOL", "🇨🇭RTR", "XSLT", "XSHZ", "XSBE" ]
 				},
 				{
 					"stations": [ "XSBE", "🇨🇭PUI", "XSLA" ]
@@ -9016,7 +9013,8 @@
 					"stations": [ "XSLC", "XSBZ", "XSCA", "XSBC", "XSBOD", "XSAI", "XSEF", "XSADF", "XSSY", "XSAG", "XSIM", "XSLU", "XSSUS", "XSN", "XSZG", "XSOL", "XSSC", "XSB" ]
 				},
 				{
-					"stations": [ "XSBE", "XSLT", "XSZG", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSLQ", "XSC" ]
+					"stations": [ "XSBE", "🇨🇭BDF", "XSHZ", "XSLT", "XSOL", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSLQ", "XSC" ],
+					"pathSuggestion": [ "XSBE", "🇨🇭BDF", "XSLT", "🇨🇭RTR", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSLQ", "XSC" ]
 				},
 				{
 					"stations": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ]
@@ -9026,6 +9024,10 @@
 				},
 				{
 					"stations": [ "XSBE", "XSTH", "XSSP", "XSFR", "XSKA", "XSGO", "🇨🇭EB", "XSBG" ]
+				},
+				{
+					"stations": [ "XSBL", "XSGRN", "XSSO", "🇨🇭OEN", "XSOL", "XSZH" ],
+					"pathSuggestion": [ "XSBL", "XSGRN", "XSSO", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ]
 				}
 			],
 			"stopsEverywhere": false
@@ -9089,6 +9091,33 @@
 				"Fahre von %s nach %s."
 			],
 			"stations": [ "XSDE", "XSB", "XSOL" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "S20 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre von %s nach %s.",
+				"Fahre den Gäubahn-Regio von %s nach %s."
+			],
+			"stations": [ "XSOL", "🇨🇭OEN", "XSSO", "XSGRN", "XSBL" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1
+		},
+		{
+			"name": "S22 der OeBB von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre von %s nach %s."
+			],
+			"stations": [ "🇨🇭OEN", "🇨🇭BTH" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -11467,6 +11496,55 @@
 			],
 			"neededCapacity": [
 				{ "name": "containers", "value": 28}
+			]
+		},
+		{
+			"group": 0,
+			"service": 4,
+			"name": "Sonderfahrt des Verein NPZ von %s nach %s",
+			"descriptions": [
+				"Der Verein NPZ fährt dieses Wochenende von %s nach %s. Doch mit welchem Zug fahren sie dieses Mal?"
+			],
+			"objects": [
+				{
+					"stations": [ "🇨🇭BTH", "XSR" ],
+					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "🇨🇭RW", "🇨🇭UZ", "🇨🇭WA", "XSSG", "XSR" ]
+				},
+				{
+					"stations": [ "🇨🇭BTH", "XSBU", "XAI" ],
+					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSBU", "XAFK", "XABL", "XAAB", "XAI" ]
+				},
+				{
+					"stations": [ "🇨🇭BTH", "XSBG", "XSLA" ],
+					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSSO", "XSGRN", "XSBL", "🇨🇭LY", "XSBE", "XSMUS", "XSTH", "XSSP", "XSFR", "XSKA", "XSGO", "XSBG", "XSLE", "XSMA", "XSMO", "🇨🇭VV", "XSLA" ]
+				}
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 0,
+			"service": 4,
+			"name": "Extrazug der OeBB Historic von %s nach %s",
+			"descriptions": [
+				"Alle Einteigen! Der Extrazug der OeBB Historic von %s nach %s fährt in Kürze ab."
+			],
+			"objects": [
+				{
+					"stations": [ "🇨🇭BTH", "🇨🇭OEN" ]
+				},
+				{
+					"stations": [ "🇨🇭BTH", "🇨🇭OEN", "XSSO" ]
+				},
+				{
+					"stations": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL" ]
+				}
+			],
+			"stopsEverywhere": false,
+			"neededCapacity": [
+				{ "name": "passengers" }
 			]
 		}
 	]

--- a/Train.json
+++ b/Train.json
@@ -1264,11 +1264,96 @@
 			"reliability": 0.9,
 			"cost": 380000,
 			"maxConnectedUnits": 2,
+			"compatibleWith": [85561, 85562],
 			"operationCosts": 75,
-			"equipments": ["CH", "AT"],
+			"equipments": ["CH", "ETCS"],
 			"exchangeTime": 60,
 			"capacity": [
 				{"name": "passengers", "value": 220}
+			]
+		},
+		{
+			"id": 85561,
+			"group": 2,
+			"service": 2,
+			"name": "SBB RBDe 561",
+			"speed": 140,
+			"weight": 280,
+			"force": 182,
+			"length": 100,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 380000,
+			"maxConnectedUnits": 2,
+			"compatibleWith": [85560, 85562],
+			"operationCosts": 75,
+			"equipments": ["CH", "DE", "AT"],
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 220}
+			]
+		},
+		{
+			"id": 85562,
+			"group": 2,
+			"service": 2,
+			"name": "SBB RBDe 562",
+			"speed": 140,
+			"weight": 280,
+			"force": 182,
+			"length": 100,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 380000,
+			"maxConnectedUnits": 2,
+			"compatibleWith": [85560, 85561],
+			"operationCosts": 75,
+			"equipments": ["CH", "FR"],
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 220}
+			]
+		},
+		{
+			"id": 85591007,
+			"group": 2,
+			"service": 2,
+			"name": "OeBB Roter Pfeil",
+			"shortcut": "OeBB RCe 2/4 607",
+			"speed": 80,
+			"weight": 38,
+			"force": 26,
+			"length": 22,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 200000,
+			"maxConnectedUnits": 1,
+			"operationCosts": 50,
+			"equipments": ["CH"],
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 58}
+			]
+		},
+		{
+			"id": 85591021,
+			"group": 2,
+			"service": 2,
+			"name": "Churchill-Pfeil",
+			"shortcut": "SBB RAe 4/8 1021",
+			"speed": 125,
+			"weight": 93,
+			"force": 26,
+			"length": 46,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 250000,
+			"maxConnectedUnits": 1,
+			"operationCosts": 80,
+			"equipments": ["CH"],
+			"exchangeTime": 60,
+			"capacity": [
+				{"name": "passengers", "value": 112}
 			]
 		},
 		{
@@ -6291,7 +6376,49 @@
 			"reliability": 0.9,
 			"cost": 250000,
 			"operationCosts": 110,
-			"equipments": ["CH", "AT", "DE", "ETCS"]
+			"equipments": ["CH", "ETCS"]
+		},
+		{
+			"id": 811142,
+			"group": 0,
+			"name": "ÖBB Rh 1142",
+			"speed": 150,
+			"weight": 84,
+			"force": 225,
+			"length": 16,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 250000,
+			"operationCosts": 110,
+			"equipments": ["DE", "AT"]
+		},
+		{
+			"id": 851042,
+			"group": 0,
+			"name": "VNPZ Rh 1042",
+			"speed": 130,
+			"weight": 84,
+			"force": 260,
+			"length": 16,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 250000,
+			"operationCosts": 110,
+			"equipments": ["CH", "DE", "AT"]
+		},
+		{
+			"id": 85421,
+			"group": 0,
+			"name": "SBB Re 421",
+			"speed": 140,
+			"weight": 85,
+			"force": 255,
+			"length": 15,
+			"drive": 1,
+			"reliability": 0.9,
+			"cost": 250000,
+			"operationCosts": 110,
+			"equipments": ["CH", "AT", "DE"]
 		},
 		{
 			"id": 85460,


### PR DESCRIPTION
- Strecken im Raum Olten/Zofingen/Solothurn/Bern dem Vorbild angenähert
- Gäubahn (Olten - Oensingen - Solothurn) hinzugefügt
- Oensingen-Balsthal-Bahn hinzugefügt
- RBDe 560 auf 3 Varianten aufgeteilt
- Re 420 auf 2 Varianten aufgeteilt
- 2 Varianten der roten Pfeile hinzugefügt
- ÖBB Rh 1042 + Schweizer "Museums"-Variante hinzugefügt
- Tasks für neue und angepasste Strecken