### PR TITLE
Württembergische Westbahn + Überarbeitung Residenzbahn

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -82103,12 +82103,12 @@
 				{
 					"start": "RSL",
 					"end": "RSLR",
-					"length": 1,
+					"length": 1
 				},
 				{
 					"start": "RSLR",
 					"end": "RGZO",
-					"length": 4,
+					"length": 4
 				},
 				{
 					"start": "RGZO",

--- a/Path.json
+++ b/Path.json
@@ -40894,24 +40894,6 @@
 		},
 		{
 			"electrified": true,
-			"group": 1,
-			"maxSpeed": 140,
-			"twistingFactor": 0.5,
-			"objects": [
-				{
-					"start": "RK",
-					"end": "TPH",
-					"length": 43
-				},
-				{
-					"start": "TPH",
-					"end": "TV",
-					"length": 25
-				}
-			]
-		},
-		{
-			"electrified": true,
 			"group": 0,
 			"twistingFactor": 0.2,
 			"maxSpeed": 160,
@@ -81882,6 +81864,269 @@
 					"length": 1,
 					"maxSpeed": 100,
 					"twistingFactor": 0.1
+				}
+			]
+		},
+		{	"name": "Württembergische Westbahn",
+			"twistingFactor": 0.2,
+			"maxSpeed": 140,
+			"electrified": true,
+			"group": 0,
+			"objects": [
+				{
+					"start": "TBM",
+					"end": "TBME",
+					"length": 2,
+					"twistingFactor": 0.5,
+					"maxSpeed": 80
+				},
+				{
+					"start": "TBME",
+					"end": "TSA",
+					"length": 5
+				},
+				{
+					"start": "TSA",
+					"end": "TSER",
+					"length": 3,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TSER",
+					"end": "TV",
+					"length": 5
+				},
+				{
+					"start": "TV",
+					"end": "TIL",
+					"length": 3,
+					"maxSpeed": 120
+				},
+				{
+					"start": "TIL",
+					"end": "TMRO",
+					"length": 5,
+					"twistingFactor": 0.0
+				},
+				{
+					"start": "TMRO",
+					"end": "TM",
+					"length": 1,
+					"maxSpeed": 100
+				},
+				{
+					"start": "TM",
+					"end": "TOET",
+					"length": 3,
+					"twistingFactor": 0.0
+				},
+				{
+					"start": "TOET",
+					"end": "TMW",
+					"length": 3,
+					"twistingFactor": 0.0
+				},
+				{
+					"start": "TMW",
+					"end": "TOED",
+					"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "TOED",
+					"end": "TKNK",
+					"length": 1,
+					"maxSpeed": 100,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "TKNK",
+					"end": "RBTI",
+					"length": 2,
+					"maxSpeed": 100,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "RBTI",
+					"end": "RBTN",
+					"length": 3,
+					"maxSpeed": 100
+				},
+				{
+					"start": "RBTN",
+					"end": "RBT",
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "RBT",
+					"end": "RBTD",
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "RBTD",
+					"end": "RGO",
+					"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.05
+				},
+				{
+					"start": "RGO",
+					"end": "RGOS",
+					"length": 1,
+					"maxSpeed": 100
+				},
+				{
+					"start": "RGOS",
+					"end": "RHSM",
+					"length": 2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "RHSM",
+					"end": "RHI",
+					"length": 2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "RHI",
+					"end": "RHIO",
+					"length": 1,
+					"maxSpeed": 130
+				},
+				{
+					"start": "RHIO",
+					"end": "RBRF",
+					"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "RBRF",
+					"end": "RBRE",
+					"length": 1,
+					"maxSpeed": 100,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "RBRE",
+					"end": "RBR",
+					"length": 2,
+					"maxSpeed": 70,
+					"twistingFactor": 0.6
+				}
+			]
+		},
+		{	"name": "Residenzbahn",
+			"twistingFactor": 0.1,
+			"maxSpeed": 140,
+			"electrified": true,
+			"group": 0,
+			"objects": [
+				{
+					"start": "TM",
+					"end": "TEZ",
+					"length": 4,
+					"twistingFactor": 0.2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TEZ",
+					"end": "TNF",
+					"length": 3,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TNF",
+					"end": "TEB",
+					"length": 2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TEB",
+					"end": "TPH",
+					"length": 4,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TPH",
+					"end": "TIP",
+					"length": 3,
+					"maxSpeed": 110
+				},
+				{
+					"start": "TIP",
+					"end": "TERS",
+					"length": 3,
+					"maxSpeed": 110
+				},
+				{
+					"start": "TERS",
+					"end": "TERW",
+					"length": 1,
+					"maxSpeed": 100
+				},
+				{
+					"start": "TERW",
+					"end": "TBIL",
+					"length": 2,
+					"maxSpeed": 120
+				},
+				{
+					"start": "TBIL",
+					"end": "TKB",
+					"length": 2,
+					"maxSpeed": 110
+				},
+				{
+					"start": "TKB",
+					"end": "TWL",
+					"length": 3,
+					"maxSpeed": 110
+				},
+				{
+					"start": "TWL",
+					"end": "RKBA",
+					"length": 2,
+					"maxSpeed": 110
+				},
+				{
+					"start": "RKBA",
+					"end": "RSL",
+					"length": 3,
+					"maxSpeed": 110
+				},
+				{
+					"start": "RSL",
+					"end": "RSLR",
+					"length": 1,
+				},
+				{
+					"start": "RSLR",
+					"end": "RGZO",
+					"length": 4,
+				},
+				{
+					"start": "RGZO",
+					"end": "RK",
+					"length": 8,
+					"maxSpeed": 120
+				}
+			]
+		},
+		{	"twistingFactor": 0.3,
+			"maxSpeed": 50,
+			"electrified": false,
+			"group": 1,
+			"objects": [
+				{
+					"start": "TMW",
+					"end": "TMBS",
+					"length": 2
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -45477,8 +45477,8 @@
 			"group": 1,
 			"name": "Vaihingen (Enz)",
 			"ril100": "TV",
-			"x": 315,
-			"y": 460,
+			"x": 316,
+			"y": 461,
 			"platformLength": 430,
 			"platforms": 4,
 			"proj": 3
@@ -91349,6 +91349,338 @@
 			"y": 763,
 			"platformLength": 150,
 			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ellental",
+			"ril100": "TBME",
+			"x": 352,
+			"y": 466,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Sachsenheim",
+			"ril100": "TSA",
+			"x": 339,
+			"y": 463,
+			"platformLength": 210,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Sersheim",
+			"ril100": "TSER",
+			"x": 328,
+			"y": 460,
+			"platformLength": 213,
+			"proj": 3
+		},
+		{
+			"group": 1,
+			"name": "Vaihingen (Enz)",
+			"ril100": "TV",
+			"x": 316,
+			"y": 461,
+			"platformLength": 430,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Illingen (Württ)",
+			"ril100": "TIL",
+			"x": 311,
+			"y": 461,
+			"platformLength": 270,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Mühlacker Rößlesweg",
+			"ril100": "TMRO",
+			"x": 303,
+			"y": 462,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Mühlacker",
+			"ril100": "TM",
+			"x": 302,
+			"y": 463,
+			"platformLength": 308,
+			"platforms": 5,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Enzberg",
+			"ril100": "TEZ",
+			"x": 295,
+			"y": 466,
+			"platformLength": 170,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Niefern",
+			"ril100": "TNF",
+			"x": 289,
+			"y": 468,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Eutingen (Baden)",
+			"ril100": "TEB",
+			"x": 282,
+			"y": 470,
+			"platformLength": 216,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ispringen",
+			"ril100": "TIP",
+			"x": 273,
+			"y": 470,
+			"platformLength": 140,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ersingen",
+			"ril100": "TERS",
+			"x": 271,
+			"y": 469,
+			"platformLength": 241,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ersingen West",
+			"ril100": "TERW",
+			"x": 270,
+			"y": 468,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Bilfingen",
+			"ril100": "TBIL",
+			"x": 268,
+			"y": 466,
+			"platformLength": 261,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Königsbach (Baden)",
+			"ril100": "TKB",
+			"x": 267,
+			"y": 464,
+			"platformLength": 140,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Wilferdingen-Singen",
+			"ril100": "TWL",
+			"x": 264,
+			"y": 465,
+			"platformLength": 195,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Kleinsteinbach",
+			"ril100": "RKBA",
+			"x": 261,
+			"y": 464,
+			"platformLength": 90,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Söllingen (b Karlsruhe)",
+			"ril100": "RSL",
+			"x": 258,
+			"y": 462,
+			"platformLength": 232,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Söllingen Reetzstr.",
+			"ril100": "RSLR",
+			"x": 257,
+			"y": 461,
+			"platformLength": 90,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Grötzingen Oberausstraße",
+			"ril100": "RGZO",
+			"x": 255,
+			"y": 459,
+			"platformLength": 120,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ötisheim",
+			"ril100": "TOET",
+			"x": 301,
+			"y": 462,
+			"platformLength": 153,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Maulbronn West",
+			"ril100": "TMW",
+			"x": 299,
+			"y": 459,
+			"platformLength": 80,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Maulbronn Stadt/Kloster",
+			"ril100": "TMBS",
+			"x": 300,
+			"y": 457,
+			"platformLength": 120,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ölbronn-Dürrn",
+			"ril100": "TOED",
+			"x": 298,
+			"y": 459,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Knittlingen-Kleinvillars",
+			"ril100": "TKNK",
+			"x": 297,
+			"y": 457,
+			"platformLength": 85,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Bretten-Ruit",
+			"ril100": "RBTI",
+			"x": 292,
+			"y": 453,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Bretten Rechberg",
+			"ril100": "RBTN",
+			"x": 290,
+			"y": 451,
+			"platformLength": 83,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Bretten",
+			"ril100": "RBT",
+			"x": 289,
+			"y": 450,
+			"platformLength": 227,
+			"platforms": 5,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Diedelsheim",
+			"ril100": "RBTD",
+			"x": 288,
+			"y": 449,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gondelsheim (Baden)",
+			"ril100": "RGO",
+			"x": 287,
+			"y": 447,
+			"platformLength": 200,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gondelsheim Schlossstadion",
+			"ril100": "RGOS",
+			"x": 286,
+			"y": 446,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Helmsheim",
+			"ril100": "RHSM",
+			"x": 285,
+			"y": 444,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Heidelsheim",
+			"ril100": "RHI",
+			"x": 284,
+			"y": 442,
+			"platformLength": 15,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Heidelsheim Nord",
+			"ril100": "RHIO",
+			"x": 283,
+			"y": 441,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Bruchsal Schlachthof",
+			"ril100": "RBRF",
+			"x": 282,
+			"y": 439,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Bruchsal Tunnelstraße",
+			"ril100": "RBRE",
+			"x": 281,
+			"y": 438,
+			"platformLength": 120,
 			"proj": 3
 		}
 	]

--- a/Station.json
+++ b/Station.json
@@ -91380,16 +91380,6 @@
 			"proj": 3
 		},
 		{
-			"group": 1,
-			"name": "Vaihingen (Enz)",
-			"ril100": "TV",
-			"x": 316,
-			"y": 461,
-			"platformLength": 430,
-			"platforms": 4,
-			"proj": 3
-		},
-		{
 			"group": 5,
 			"name": "Illingen (Württ)",
 			"ril100": "TIL",

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -10027,8 +10027,8 @@
 			],
 			"objects": [
 				{
-					"stations": [ "RK", "TPH", "TV", "TS", "TSG", "TA", "TEL", "TC", "NAN", "NN", "NER", "NBA", "NLF", "NK", "US", "UGW", "UNM", "LL" ],
-					"pathSuggestion": [ "RK", "TPH", "TV", "TS", "TWN", "TSF", "TSG", "TA", "TEL", "TJZ", "TC", "NSNE", "NAN", "NN", "NER", "NBA", "NED", "NLF", "NHM", "NK", "US", "UR", "UGW", "UPF", "UGH", "UKO", "UNM", "LL" ]
+					"stations": [ "RK", "TPH", "TM", "TV", "TS", "TSG", "TA", "TEL", "TC", "NAN", "NN", "NER", "NBA", "NLF", "NK", "US", "UGW", "UNM", "LL" ],
+					"pathSuggestion": [ "RK", "TPH", "TM", "TV", "TS", "TWN", "TSF", "TSG", "TA", "TEL", "TJZ", "TC", "NSNE", "NAN", "NN", "NER", "NBA", "NED", "NLF", "NHM", "NK", "US", "UR", "UGW", "UPF", "UGH", "UKO", "UNM", "LL" ]
 				}
 			]
 		},
@@ -11596,7 +11596,7 @@
 				"Du wurdest beauftragt, um eine Testfahrt auf der künftigen Strecke des RE1 vor der Inbetriebnahme von S21 durchzuführen. Für die Fahrt auf der Schnellfahrstrecke brauchst du ein ETCS-fähiges Fahrzeug.",
 				"Stuttgart 21 wird bald fertig und es heißt nun: Testfahrten durchführen. Fahre die künftige Strecke des RE1 von %s bis %s ab."
 			],
-			"stations": [ "RK", "TPH", "TV", "TS", "TMKL", "TU", "TBI", "TAU", "TRB", "TMK", "TF", "MLIR" ],
+			"stations": [ "RK", "TWL", "TPH", "TM", "TV", "TS", "TMKL", "TU", "TBI", "TAU", "TRB", "TMK", "TF", "MLIR" ],
 			"neededCapacity": [
 				{ "name": "passengers", "value": 10 }
 			]
@@ -11711,8 +11711,16 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Fahre auf der Linie RE1 von %s nach %s."
 			],
-			"stations": [ "RK", "TPH", "TV", "TS", "TSF", "TSG", "TA" ],
-			"pathSuggestion": [ "RK", "TPH", "TV", "TS", "TWN", "TSF", "TSG", "TA" ],
+			"objects": [
+				{
+					"stations": [ "RK", "TWL", "TPH", "TM", "TV", "TS" ],
+					"pathSuggestion": [ "RK", "TPH", "TM", "TV", "TS" ]
+				},
+				{
+					"stations": [ "RK", "TPH", "TM", "TV", "TS", "TSF", "TSG", "TA" ],
+					"pathSuggestion": [ "RK", "TPH", "TM", "TV", "TS", "TWN", "TSF", "TSG", "TA" ]
+				}
+			],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
@@ -11885,6 +11893,129 @@
 			],
 			"stations": [ "XFSTG", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
 			"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "MEX17a von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie MEX17a von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre die Metropolexpress-Linie 17a von %s bis %s. Sei dabei pünktlich!"
+			],
+			"stations": [ "TS", "TLU", "TBM", "TBME", "TSA", "TSER", "TV", "TIL", "TMRO", "TM", "TEZ", "TNF", "TEB", "TPH", "TWL", "RK" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Radexpress Enztäler von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Es ist Sonntag und daher wollen viele Radler entlang der Enz auf dem Enztalradweg fahren. Bringe den verlängerten MEX17a von %s nach %s.",
+				"Hoch die Hände, Wochenende! Fahre den Radexpress Enztäler nach %2$s."
+			],
+			"stations": [ "TS", "TLU", "TBM", "TBME", "TSA", "TSER", "TV", "TIL", "TMRO", "TM", "TEZ", "TNF", "TEB", "TPH", "TNE", "TWB" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "MEX17c von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie MEX17c von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre die Metropolexpress-Linie 17c von %s bis %s. Sei dabei pünktlich!"
+			],
+			"stations": [ "TS", "TLU", "TBM", "TBME", "TSA", "TSER", "TV", "TIL", "TMRO", "TM", "TOET", "TMW", "TOED", "TKNK", "RBTI", "RBTN", "RBT", "RBTD", "RGO", "RGOS", "RHSM", "RHI", "RHIO", "RBRF", "RBRE", "RBR" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RB17c von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie RB17c von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre die Regionalbahn der Linie 17c von %s bis %s. Sei dabei pünktlich!"
+			],
+			"stations": [ "TM", "TOET", "TMW", "TOED", "TKNK", "RBTI", "RBTN", "RBT", "RBTD", "RGO", "RGOS", "RHSM", "RHI", "RHIO", "RBRF", "RBRE", "RBR" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RE71 von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie RE71 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre den Fliegenden Heidelberger von %s nach %s."
+			],
+			"stations": [ "TM", "RBT", "RBR", "RBSK", "RWS", "RH" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "S5 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre auf der Stadtbahnlinie S5 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre die Linie S5 von %s bis %s. Halte dabei an allen Unterwegsbahnhöfen."
+			],
+			"stations": [ "TPH", "TWL", "RK" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "S51 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre auf der Stadtbahnlinie S51 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre die Linie S51 von %s bis %s. Halte dabei an allen Unterwegsbahnhöfen."
+			],
+			"stations": [ "TPH", "TWL", "RK", "RWRT", "RGE" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Schienenbus nach %2$s",
+			"service": 4,
+			"descriptions": [
+				"Fahre den Ausflugszug von %s nach %s. Setze nach Möglichkeit einen Schienenbus ein.",
+				"Fahre die Besucher des Kloster Maulbronn nach %2$s."
+			],
+			"objects": [
+				{
+					"stations": [ "TS", "TKH", "TLU", "TBM", "TBME", "TM", "TMW", "TMBS" ]
+				},
+				{
+					"stations": [ "TMBS", "TMW" ]
+				},
+				{
+					"stations": [ "TMBS", "TMW", "TPH" ],
+					"pathSuggestion": [ "TMBS", "TMW", "TM", "TPH" ]
+				}
+			],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -11857,7 +11857,7 @@
 			"objects": [
 				{
 					"stations": [ "RK", "TWL", "TPH", "TM", "TV", "TS" ],
-					"pathSuggestion": [ "RK", "TPH", "TM", "TV", "TS" ]
+					"pathSuggestion": [ "RK", "TWL", "TPH", "TM", "TV", "TS" ]
 				},
 				{
 					"stations": [ "RK", "TPH", "TM", "TV", "TS", "TSF", "TSG", "TA" ],


### PR DESCRIPTION
Folgende Aufgaben aus #977 werden eingefügt:

neue Strecken:
- Bietigheim-Bissingen - Vaihingen (Enz)
- Mühlacker - Bretten - Bruchsal
- Maulbronn West - Maulbronn Stadt

überarbeitete Strecken:
- Vaihingen (Enz) - Karlsruhe (TV - TWL mit allen Unterwegsbahnhöfen, TWL - RK nur ausgewählte Halte)

Aufgaben:
- RE1 Karlsruhe - Stuttgart - Aalen (neue Halte in TWL + TM)
- IC Karlsruhe - Nürnberg - Leipzig (neuer Halt TM)
- MEX17a Stuttgart - Pforzheim - Karlsruhe
- MEX17a Stuttgart - Bad Wildbad (Enztäler Freizeitexpress)
- MEX17c Stuttgart - Bruchsal
- RB17c Mühlacker - Bretten - Bruchsal
- RE71 Mühlacker - Heidelberg
- S5 Pforzheim - Karlsruhe
- S51 Pforzheim - Söllingen - Germersheim
- S6 Bad Wildbad - Karlsruhe (neue Halte zw. TPH - RK)
- Ausflugszug Stuttgart - Mühlacker - Maulbronn West - Maulbronn Stadt / Pforzheim - Maulbronn West - Maulbronn Stadt