### PR TITLE
Eurodual Zulassung für Slovenien, Kroatien & Serbien

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -2871,7 +2871,7 @@
 			"length": 200,
 			"drive": 1,
 			"reliability": 1,
-			"cost": 5250000,	
+			"cost": 5250000,
 			"equipments": ["ETCS", "TVM", "ES", "FR", "1668mm", "1435mm"],
 			"maxConnectedUnits": 2,
 			"operationCosts": 110,
@@ -6093,7 +6093,7 @@
 			"reliability": 1,
 			"cost": 600000,
 			"operationCosts": 130,
-			"equipments": [ "FR", "ETCS", "AT", "DE", "TR", "ES", "NL", "BE", "CH", "SE", "IT", "LU", "GB", "NO" ]
+			"equipments": [ "FR", "ETCS", "AT", "DE", "TR", "ES", "NL", "BE", "CH", "SE", "IT", "LU", "GB", "NO", "SI", "HR", "RS" ]
 		},
 		{
 			"id": 54362,
@@ -7748,7 +7748,7 @@
             "cost": 370000,
             "operationCosts": 125,
             "equipments": ["CH", "DE", "AT", "FR", "IT", "XK", "ES", "ETCS"]
-        },	
+        },
 		{
             "id": 72000,
             "group": 0,
@@ -7762,7 +7762,7 @@
             "cost": 450000,
             "operationCosts": 125,
             "equipments": ["CH", "DE", "BE", "IT", "NL", "FR", "SE", "DK", "PL", "ETCS"]
-        }, 
+        },
 		{
 			"id": 17,
 			"group": 0,


### PR DESCRIPTION
https://www.europeanlocpool.com/de/eurodual-lokomotive/eurodual-osteuropa/