### PR TITLE
Fix des Ausflugszuges Stuttgart - Maulbronn

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -12149,7 +12149,7 @@
 			],
 			"objects": [
 				{
-					"stations": [ "TS", "TKH", "TLU", "TBM", "TBME", "TM", "TMW", "TMBS" ]
+					"stations": [ "TS", "TKH", "TLU", "TBM", "TBME", "TM", "TMW", "TMBS" ],
 					"pathSuggestion": [ "TS", "TKH", "TLU", "TBM", "TBME", "TSA", "TSER", "TV", "TIL", "TMRO", "TM", "TMW", "TMBS" ]
 				},
 				{


### PR DESCRIPTION
Die Route von Stuttgart nach Maulbronn kann jetzt nicht vervollständigt werden, daher jetzt mit pathSuggestion an allen Stationen, dazu statt Ausschreibung nun eine Direktvergabe