### PR TITLE
Schweizer Mittelland: kleine Fixes

### DIFF
--- a/TaskModel.json
+++ b/TaskModel.json
@@ -11549,7 +11549,7 @@
 			]
 		},
 		{
-			"group": 0,
+			"group": 1,
 			"name": "S41 der S-Bahn Bern von %s nach %s",
 			"service": 3,
 			"descriptions": [

--- a/Train.json
+++ b/Train.json
@@ -1317,7 +1317,7 @@
 		{
 			"id": 85591007,
 			"group": 2,
-			"service": 2,
+			"service": 4,
 			"name": "OeBB Roter Pfeil",
 			"shortcut": "OeBB RCe 2/4 607",
 			"speed": 80,
@@ -1338,7 +1338,7 @@
 		{
 			"id": 85591021,
 			"group": 2,
-			"service": 2,
+			"service": 4,
 			"name": "Churchill-Pfeil",
 			"shortcut": "SBB RAe 4/8 1021",
 			"speed": 125,
@@ -1353,7 +1353,8 @@
 			"equipments": ["CH"],
 			"exchangeTime": 60,
 			"capacity": [
-				{"name": "passengers", "value": 112}
+				{"name": "passengers", "value": 56},
+				{"name": "bistroseats", "value": 56}
 			]
 		},
 		{


### PR DESCRIPTION
- S41 neu Ausschreibung statt Direktvergabe
- Rote Pfeile neu mit Service 4 (Sonderzug)
- Churchill-Pfeil neu zur Hälfte mit Speiseplätzen (in Zukunft folgen Sonderzug -Tasks)