### PR TITLE
Elektrifizierung Angermünde-Passow

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -56816,7 +56816,7 @@
 				{
 					"start": "WA",
 					"end": "WPS",
-					"electrified": false,
+					"electrified": true,
 					"length": 18,
 					"maxSpeed": 60
 				},


### PR DESCRIPTION
Wie in der Realität sollen Züge bis nach Passow elektrisch fahren können.
Gehört eigentlich zum Request für neue Güterzüge.