### PR TITLE
Fix Bahnsteiglänge Heidelsheim

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -92203,7 +92203,7 @@
 			"ril100": "RHI",
 			"x": 284,
 			"y": 442,
-			"platformLength": 15,
+			"platformLength": 150,
 			"proj": 3
 		},
 		{


### PR DESCRIPTION
Eine null mehr drangehängt an den Bahnsteig in Heidelsheim