### PR TITLE
Projekt Gotthard - Nordzulauf

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -71657,10 +71657,17 @@
 				},
 				{
 					"start": "XSKS",
-					"end": "XSLB",
-					"length": 15,
+					"end": "🇨🇭OTH",
+					"length": 12,
 					"maxSpeed": 140,
 					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇨🇭OTH",
+					"end": "XSLB",
+					"length": 4,
+					"maxSpeed": 130,
+					"twistingFactor": 0.1
 				},
 				{
 					"start": "XSLB",
@@ -73487,27 +73494,6 @@
 					"length": 17,
 					"maxSpeed": 120,
 					"twistingFactor": 0.3
-				},
-				{
-					"start": "XSLU",
-					"end": "🇨🇭MERL",
-					"length": 14,
-					"maxSpeed": 80,
-					"twistingFactor": 0.3
-				},
-				{
-					"start": "🇨🇭MERL",
-					"end": "XSKN",
-					"length": 2,
-					"maxSpeed": 80,
-					"twistingFactor": 0.1
-				},
-				{
-					"start": "XSKN",
-					"end": "XSIM",
-					"length": 3,
-					"maxSpeed": 80,
-					"twistingFactor": 0.1
 				}
 			]
 		},
@@ -73581,29 +73567,6 @@
 						"CH",
 						"ETCS"
 					]
-				}
-			]
-		},
-		{
-			"electrified": true,
-			"group": 0,
-			"neededEquipments": [
-				"CH"
-			],
-			"objects": [
-				{
-					"start": "XSTW",
-					"end": "XSZU",
-					"length": 17,
-					"maxSpeed": 100,
-					"twistingFactor": 0.32
-				},
-				{
-					"start": "XSZU",
-					"end": "XSAG",
-					"length": 16,
-					"maxSpeed": 75,
-					"twistingFactor": 0.34
 				}
 			]
 		},
@@ -82800,6 +82763,379 @@
 					"start": "TMW",
 					"end": "TMBS",
 					"length": 2
+				}
+			]
+		},
+		{
+			"name": "Aargauische Südbahn",
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"start": "XSBRU",
+					"end": "🇨🇭LUPF",
+					"length": 4,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭LUPF",
+					"end": "🇨🇭BIRR",
+					"length": 1,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BIRR",
+					"end": "🇨🇭OTH",
+					"length": 3,
+					"maxSpeed": 120,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭OTH",
+					"end": "🇨🇭HDK",
+					"length": 2,
+					"maxSpeed": 110,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XSLB",
+					"end": "🇨🇭HDK",
+					"length": 3,
+					"maxSpeed": 115,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭HDK",
+					"end": "🇨🇭DOT",
+					"length": 3,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭DOT",
+					"end": "🇨🇭WO",
+					"length": 4,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭WO",
+					"end": "🇨🇭BOS",
+					"length": 6,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BOS",
+					"end": "🇨🇭MI",
+					"length": 3,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭MI",
+					"end": "🇨🇭BNZ",
+					"length": 4,
+					"maxSpeed": 120,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BNZ",
+					"end": "🇨🇭MUEH",
+					"length": 3,
+					"maxSpeed": 115,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭MUEH",
+					"end": "🇨🇭SINS",
+					"length": 4,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭SINS",
+					"end": "🇨🇭OI",
+					"length": 2,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭OI",
+					"end": "🇨🇭RK",
+					"length": 4,
+					"maxSpeed": 105,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭RK",
+					"end": "XSIM",
+					"length": 7,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"start": "XSLU",
+					"end": "🇨🇭EBI",
+					"length": 9,
+					"maxSpeed": 90,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭EBI",
+					"end": "🇨🇭BURN",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BURN",
+					"end": "🇨🇭LBD",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭LBD",
+					"end": "🇨🇭GSK",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭GSK",
+					"end": "🇨🇭RK",
+					"length": 4,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭RK",
+					"end": "🇨🇭HUCH",
+					"length": 3,
+					"maxSpeed": 115,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭HUCH",
+					"end": "🇨🇭HUZY",
+					"length": 1,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭HUZY",
+					"end": "🇨🇭CHAM",
+					"length": 1,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭CHAM",
+					"end": "🇨🇭CHAA",
+					"length": 1,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭CHAA",
+					"end": "🇨🇭KMUE",
+					"length": 1,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭KMUE",
+					"end": "🇨🇭ZGSE",
+					"length": 2,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ZGSE",
+					"end": "XSZU",
+					"length": 1,
+					"maxSpeed": 110,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XSZU",
+					"end": "🇨🇭BAAL",
+					"length": 1,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BAAL",
+					"end": "🇨🇭BAAN",
+					"length": 1,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BAAN",
+					"end": "🇨🇭BAA",
+					"length": 1,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭BAA",
+					"end": "🇨🇭LITT",
+					"length": 2,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭LITT",
+					"end": "🇨🇭SBG",
+					"length": 4,
+					"maxSpeed": 125,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭SBG",
+					"end": "🇨🇭HGO",
+					"length": 3,
+					"maxSpeed": 90,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭HGO",
+					"end": "🇨🇭ORDD",
+					"length": 2,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ORDD",
+					"end": "XSTW",
+					"length": 2,
+					"maxSpeed": 95,
+					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 1,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"start": "XSLU",
+					"end": "🇨🇭LZVH",
+					"length": 6,
+					"maxSpeed": 80,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭LZVH",
+					"end": "🇨🇭MEGZ",
+					"length": 4,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭MEGZ",
+					"end": "🇨🇭MEG",
+					"length": 1,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭MEG",
+					"end": "🇨🇭MERL",
+					"length": 3,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭MERL",
+					"end": "XSKN",
+					"length": 2,
+					"maxSpeed": 85,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "XSKN",
+					"end": "XSIM",
+					"length": 3,
+					"maxSpeed": 80,
+					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 1,
+			"neededEquipments": [
+				"CH"
+			],
+			"objects": [
+				{
+					"start": "XSZU",
+					"end": "🇨🇭ZGPP",
+					"length": 1,
+					"maxSpeed": 70,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ZGPP",
+					"end": "🇨🇭ZGCA",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ZGCA",
+					"end": "🇨🇭ZGFR",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ZGFR",
+					"end": "🇨🇭ZGO",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭ZGO",
+					"end": "🇨🇭WCHO",
+					"length": 4,
+					"maxSpeed": 80,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭WCHO",
+					"end": "🇨🇭WCHW",
+					"length": 1,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇨🇭WCHW",
+					"end": "XSAG",
+					"length": 6,
+					"maxSpeed": 75,
+					"twistingFactor": 0.1
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -75129,19 +75129,19 @@
 			"ril100": "XSKS",
 			"group": 2,
 			"x": 245,
-			"y": 720,
+			"y": 721,
 			"platformLength": 391,
-			"platforms": 3,
+			"platforms": 4,
 			"proj": 3
 		},
 		{
 			"name": "Lenzburg",
 			"ril100": "XSLB",
 			"group": 2,
-			"x": 220,
-			"y": 726,
+			"x": 223,
+			"y": 725,
 			"platformLength": 401,
-			"platforms": 5,
+			"platforms": 7,
 			"proj": 3
 		},
 		{
@@ -75428,10 +75428,10 @@
 			"name": "Brugg AG",
 			"ril100": "XSBRU",
 			"group": 2,
-			"x": 225,
-			"y": 712,
+			"x": 228,
+			"y": 713,
 			"platformLength": 425,
-			"platforms": 3,
+			"platforms": 5,
 			"proj": 3
 		},
 		{
@@ -76871,10 +76871,10 @@
 			"name": "Luzern",
 			"ril100": "XSLU",
 			"group": 0,
-			"x": 236,
+			"x": 241,
 			"y": 785,
 			"platformLength": 452,
-			"platforms": 15,
+			"platforms": 14,
 			"proj": 3
 		},
 		{
@@ -76884,7 +76884,7 @@
 			"x": 120,
 			"y": 802,
 			"platformLength": 539,
-			"platforms": 7,
+			"platforms": 14,
 			"proj": 3
 		},
 		{
@@ -77097,10 +77097,10 @@
 			"name": "Zug (CH)",
 			"ril100": "XSZU",
 			"group": 1,
-			"x": 267,
-			"y": 765,
+			"x": 270,
+			"y": 764,
 			"platformLength": 576,
-			"platforms": 5,
+			"platforms": 7,
 			"proj": 3
 		},
 		{
@@ -92349,6 +92349,392 @@
 			"group": 6,
 			"x": 310,
 			"y": 878,
+			"proj": 3
+		},
+		{
+			"name": "Lupfig",
+			"ril100": "🇨🇭LUPF",
+			"group": 5,
+			"x": 229,
+			"y": 719,
+			"platformLength": 224,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Birr",
+			"ril100": "🇨🇭BIRR",
+			"group": 5,
+			"x": 229,
+			"y": 720,
+			"platformLength": 220,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Othmarsingen",
+			"ril100": "🇨🇭OTH",
+			"group": 2,
+			"x": 232,
+			"y": 724,
+			"platformLength": 320,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Hendschiken",
+			"ril100": "🇨🇭HDK",
+			"group": 2,
+			"x": 229,
+			"y": 730,
+			"platformLength": 236,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Dottikon-Dintikon",
+			"ril100": "🇨🇭DOT",
+			"group": 5,
+			"x": 231,
+			"y": 731,
+			"platformLength": 224,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Wohlen AG",
+			"ril100": "🇨🇭WO",
+			"group": 2,
+			"x": 236,
+			"y": 735,
+			"platformLength": 244,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Boswil-Bünzen",
+			"ril100": "🇨🇭BOS",
+			"group": 5,
+			"x": 243,
+			"y": 742,
+			"platformLength": 220,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Muri AG",
+			"ril100": "🇨🇭MI",
+			"group": 2,
+			"x": 247,
+			"y": 747,
+			"platformLength": 219,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Benzenschwil",
+			"ril100": "🇨🇭BNZ",
+			"group": 5,
+			"x": 249,
+			"y": 752,
+			"platformLength": 217,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Mühlau",
+			"ril100": "🇨🇭MUEH",
+			"group": 5,
+			"x": 253,
+			"y": 756,
+			"platformLength": 179,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Sins",
+			"ril100": "🇨🇭SINS",
+			"group": 5,
+			"x": 253,
+			"y": 756,
+			"platformLength": 214,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Oberrüti",
+			"ril100": "🇨🇭OI",
+			"group": 5,
+			"x": 253,
+			"y": 756,
+			"platformLength": 164,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Rotkreuz",
+			"ril100": "🇨🇭RK",
+			"group": 2,
+			"x": 253,
+			"y": 756,
+			"platformLength": 458,
+			"platforms": 5,
+			"proj": 3
+		},
+		{
+			"name": "Ebikon",
+			"ril100": "🇨🇭EBI",
+			"group": 5,
+			"x": 246,
+			"y": 780,
+			"platformLength": 236,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Buchrain",
+			"ril100": "🇨🇭BURN",
+			"group": 5,
+			"x": 248,
+			"y": 778,
+			"platformLength": 149,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Root D4",
+			"ril100": "🇨🇭LBD",
+			"group": 5,
+			"x": 250,
+			"y": 776,
+			"platformLength": 220,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Gisikon-Root",
+			"ril100": "🇨🇭GSK",
+			"group": 5,
+			"x": 253,
+			"y": 773,
+			"platformLength": 228,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Luzern Verkehrshaus",
+			"ril100": "🇨🇭LZVH",
+			"group": 5,
+			"x": 245,
+			"y": 785,
+			"platformLength": 204,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Meggen Zentrum",
+			"ril100": "🇨🇭MEGZ",
+			"group": 5,
+			"x": 250,
+			"y": 786,
+			"platformLength": 180,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Meggen",
+			"ril100": "🇨🇭MEG",
+			"group": 5,
+			"x": 252,
+			"y": 785,
+			"platformLength": 152,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Hünenberg Chämleten",
+			"ril100": "🇨🇭HUCH",
+			"group": 5,
+			"x": 261,
+			"y": 766,
+			"platformLength": 150,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Hünenberg Zythus",
+			"ril100": "🇨🇭HUZY",
+			"group": 5,
+			"x": 261,
+			"y": 765,
+			"platformLength": 150,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Cham (CH)",
+			"ril100": "🇨🇭CHAM",
+			"group": 5,
+			"x": 262,
+			"y": 764,
+			"platformLength": 230,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Cham Alpenblick",
+			"ril100": "🇨🇭CHAA",
+			"group": 5,
+			"x": 264,
+			"y": 764,
+			"platformLength": 150,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Zug Chollermüli",
+			"ril100": "🇨🇭KMUE",
+			"group": 5,
+			"x": 266,
+			"y": 764,
+			"platformLength": 151,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Zug Schutzengel",
+			"ril100": "🇨🇭ZGSE",
+			"group": 5,
+			"x": 269,
+			"y": 764,
+			"platformLength": 150,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Baar Lindenpark",
+			"ril100": "🇨🇭BAAL",
+			"group": 5,
+			"x": 270,
+			"y": 763,
+			"platformLength": 150,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Baar Neufeld",
+			"ril100": "🇨🇭BAAN",
+			"group": 5,
+			"x": 270,
+			"y": 762,
+			"platformLength": 149,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Baar",
+			"ril100": "🇨🇭BAA",
+			"group": 5,
+			"x": 271,
+			"y": 761,
+			"platformLength": 320,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Litti",
+			"ril100": "🇨🇭LITT",
+			"group": 6,
+			"x": 273,
+			"y": 759,
+			"proj": 3
+		},
+		{
+			"name": "Sihlbrugg",
+			"ril100": "🇨🇭SBG",
+			"group": 6,
+			"x": 279,
+			"y": 754,
+			"proj": 3
+		},
+		{
+			"name": "Horgen Oberdorf",
+			"ril100": "🇨🇭HGO",
+			"group": 5,
+			"x": 281,
+			"y": 750,
+			"platformLength": 317,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Oberrieden Dorf",
+			"ril100": "🇨🇭ORDD",
+			"group": 5,
+			"x": 279,
+			"y": 747,
+			"platformLength": 310,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Zug Postplatz",
+			"ril100": "🇨🇭ZGPP",
+			"group": 5,
+			"x": 270,
+			"y": 765,
+			"platformLength": 79,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Zug Casino",
+			"ril100": "🇨🇭ZGCA",
+			"group": 5,
+			"x": 270,
+			"y": 766,
+			"platformLength": 80,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Zug Fridbach",
+			"ril100": "🇨🇭ZGFR",
+			"group": 5,
+			"x": 270,
+			"y": 767,
+			"platformLength": 80,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Zug Oberwil",
+			"ril100": "🇨🇭ZGO",
+			"group": 5,
+			"x": 269,
+			"y": 769,
+			"platformLength": 80,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Walchwil Hörndli",
+			"ril100": "🇨🇭WCHO",
+			"group": 5,
+			"x": 269,
+			"y": 775,
+			"platformLength": 80,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Walchwil",
+			"ril100": "🇨🇭WCHW",
+			"group": 5,
+			"x": 270,
+			"y": 777,
+			"platformLength": 239,
+			"platforms": 2,
 			"proj": 3
 		}
 	]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -9220,7 +9220,7 @@
 					"stations": [ "XSBE", "🇨🇭BDF", "XSHZ", "XSLT", "XSOL", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSLQ", "XSC" ]
 				},
 				{
-					"stations": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ]
+					"stations": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ],
 					"pathSuggestion": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "🇨🇭OTH", "XSKS", "XSDI", "XSZH" ]
 				},
 				{

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -337,7 +337,7 @@
 				},
 				{
 					"stations": [ "XSB", "XSOL", "XSLU", "XSAG", "XSBZ", "XSL" ],
-					"pathSuggestion": [ "XSB", "XSOL", "XSZG", "XSLU", "XSAG", "XSADF", "XSBC", "XSBZ", "XSL" ]
+					"pathSuggestion": [ "XSB", "XSOL", "XSZG", "XSLU", "🇨🇭RK", "XSAG", "XSADF", "XSBC", "XSBZ", "XSL" ]
 				},
 				{
 					"stations": [ "XSB", "XSOL", "XSBE", "XSTH", "XSSP", "XSVI", "XSBG" ],
@@ -357,7 +357,7 @@
 				},
 				{
 					"stations": [ "XSZH", "XSBE", "XSTH", "XSSP", "XSIO" ],
-					"pathSuggestion": [ "XSZH", "XSKS", "XSLB", "XSOL", "🇨🇭RTR", "🇨🇭WANZ", "XSBE", "XSTH", "XSSP", "XSIO" ]
+					"pathSuggestion": [ "XSZH", "XSKS", "🇨🇭OTH", "XSLB", "XSOL", "🇨🇭RTR", "🇨🇭WANZ", "XSBE", "XSTH", "XSSP", "XSIO" ]
 				}
 			]
 		},
@@ -376,14 +376,14 @@
 			"objects": [
 				{
 					"stations": [ "XSLU", "XSZU", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG", "XSRS", "XSSM", "XSHR", "XSAS", "XSBU", "XSSR", "XSLQ", "XSC" ],
-					"pathSuggestion": [ "XSLU", "XSAG", "XSZU", "XSTW", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG", "XSRS", "XSSM", "XSHR", "XSAS", "XSBU", "XSSR", "XSLQ", "XSC" ]
+					"pathSuggestion": [ "XSLU", "🇨🇭RK", "XSZU", "XSTW", "XSZH", "XSZO", "XSWT", "XSWI", "XSSG", "XSRS", "XSSM", "XSHR", "XSAS", "XSBU", "XSSR", "XSLQ", "XSC" ]
 				}
 			]
 		},
 		{
 			"name": "ECE von %s nach %s",
 			"descriptions": [
-				"Bringe den Eurocity-Express von %s nach %s.",
+				"Bringe den EuroCity-Express von %s nach %s.",
 				"Bring die Fahrgäste in dem ECE pünktlich nach %2$s.",
 				"Fahre den ECE störungsfrei nach %2$s.",
 				"Fahre zwischen Deutschland, der Schweiz und Italien nach %2$s."
@@ -9178,7 +9178,7 @@
 					"stations": [ "RSCF", "XSZO", "XSZH" ]
 				},
 				{
-					"stations": [ "XSZH", "XSKS", "XSLB", "XSOL" ]
+					"stations": [ "XSZH", "XSKS", "🇨🇭OTH", "XSLB", "XSOL" ]
 				},
 				{
 					"stations": [ "XSBL", "XSGRN", "XSDE" ]
@@ -9221,6 +9221,7 @@
 				},
 				{
 					"stations": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ]
+					"pathSuggestion": [ "XSB", "XSSC", "XSOL", "XSA", "XSLB", "🇨🇭OTH", "XSKS", "XSDI", "XSZH" ]
 				},
 				{
 					"stations": [ "XSBG", "XSVI", "XSLE", "XSSI", "XSSN", "XSMA", "XSAL", "XSMO", "🇨🇭VV", "XSLA", "XSMG", "🇨🇭GLA", "🇨🇭NY", "XSGE" ]
@@ -9230,7 +9231,7 @@
 				},
 				{
 					"stations": [ "XSBL", "XSGRN", "XSSO", "🇨🇭OEN", "XSOL", "XSZH" ],
-					"pathSuggestion": [ "XSBL", "XSGRN", "XSSO", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH" ]
+					"pathSuggestion": [ "XSBL", "XSGRN", "XSSO", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "🇨🇭OTH", "XSKS", "XSDI", "XSZH" ]
 				}
 			],
 			"stopsEverywhere": false
@@ -11873,7 +11874,7 @@
 				},
 				{
 					"stations": [ "XSZH", "XSB", "RB", "RF", "RBB", "RK", "RM", "FMZ", "KKO", "KB", "KK", "KD", "EDG", "EE", "EBO", "EDO", "EMST", "HO", "HB", "AHAR", "AH", "AA" ],
-					"pathSuggestion": [ "XSZH", "XSKS", "XSLB", "XSOL", "XSSC", "XSB", "RB", "RML", "RF", "RO", "RAP", "RBB", "RK", "RGN", "RSAB", "RM", "RFT", "FWOR", "FMZ", "FGAL", "FBGK", "KBOP", "KKO", "KAND", "KB", "KKAS", "KK", "KD", "EDG", "EE", "EBO", "EDO", "EMST", "HO", "HB", "AROG", "ABLZ", "AHAR", "AH", "AA" ]
+					"pathSuggestion": [ "XSZH", "XSKS", "🇨🇭OTH", "XSLB", "XSOL", "XSSC", "XSB", "RB", "RML", "RF", "RO", "RAP", "RBB", "RK", "RGN", "RSAB", "RM", "RFT", "FWOR", "FMZ", "FGAL", "FBGK", "KBOP", "KKO", "KAND", "KB", "KKAS", "KK", "KD", "EDG", "EE", "EBO", "EDO", "EMST", "HO", "HB", "AROG", "ABLZ", "AHAR", "AH", "AA" ]
 				}
 			],
 			"neededCapacity": [
@@ -11940,11 +11941,11 @@
 			"objects": [
 				{
 					"stations": [ "🇨🇭BTH", "XSR" ],
-					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "🇨🇭RW", "🇨🇭UZ", "🇨🇭WA", "XSSG", "XSR" ]
+					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "🇨🇭OTH", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "🇨🇭RW", "🇨🇭UZ", "🇨🇭WA", "XSSG", "XSR" ]
 				},
 				{
 					"stations": [ "🇨🇭BTH", "XSBU", "XAI" ],
-					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSBU", "XAFK", "XABL", "XAAB", "XAI" ]
+					"pathSuggestion": [ "🇨🇭BTH", "🇨🇭OEN", "XSOL", "XSA", "XSLB", "🇨🇭OTH", "XSKS", "XSDI", "XSZH", "XSTW", "XSWW", "XSPF", "XSZB", "XSWA", "XSSR", "XSBU", "XAFK", "XABL", "XAAB", "XAI" ]
 				},
 				{
 					"stations": [ "🇨🇭BTH", "XSBG", "XSLA" ],
@@ -12199,7 +12200,7 @@
 			"descriptions": [
 				"Fahre von %s nach %s."
 			],
-			"stations": [ "XSLU", "🇨🇭MERL", "XSIM", "XSAG", "🇨🇭BRU" ],
+			"stations": [ "XSLU", "🇨🇭LZVH", "🇨🇭MERL", "XSIM", "XSAG", "🇨🇭BRU" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -12224,7 +12225,7 @@
 				},
 				{
 					"stations": [ "XSLC", "XSBZ", "XSCA", "XSBC", "XSBOD", "🇨🇭LAV", "XSFD", "🇨🇭AP", "XSAI", "XSGS", "XSEF", "XSADF", "🇨🇭FL", "🇨🇭BRU", "XSSY", "XSAG", "XSLU", "XSOL", "XSB" ],
-					"pathSuggestion": [ "XSLC", "XSBZ", "XSCA", "XSBC", "XSBOD", "🇨🇭LAV", "XSFD", "🇨🇭AP", "XSAI", "XSGS", "XSEF", "XSADF", "🇨🇭FL", "🇨🇭BRU", "XSSY", "XSAG", "XSIM", "XSLU", "XSSUS", "XSZG", "XSOL", "XSB" ]
+					"pathSuggestion": [ "XSLC", "XSBZ", "XSCA", "XSBC", "XSBOD", "🇨🇭LAV", "XSFD", "🇨🇭AP", "XSAI", "XSGS", "XSEF", "XSADF", "🇨🇭FL", "🇨🇭BRU", "XSSY", "XSAG", "XSIM", "🇨🇭RK", "XSLU", "XSSUS", "XSZG", "XSOL", "XSB" ]
 				}
 			]
 		}

--- a/Train.json
+++ b/Train.json
@@ -193,7 +193,7 @@
 			"cost": 3000000,
 			"maxConnectedUnits": 2,
 			"operationCosts": 70,
-			"equipments": ["ETCS", "AT", "DE"],
+			"equipments": ["ETCS", "AT", "DE", "CH"],
 			"exchangeTime": 120,
 			"capacity": [
 				{"name": "passengers", "value": 376},
@@ -5762,7 +5762,7 @@
 			"reliability": 0.9,
 			"cost": 350000,
 			"operationCosts": 100,
-			"equipments": ["AT", "DE", "CH"]
+			"equipments": ["AT", "DE"]
 		},
 		{
 			"id": 102,
@@ -5849,7 +5849,7 @@
 			"reliability": 0.96,
 			"cost": 370000,
 			"operationCosts": 105,
-			"equipments": ["FR", "CH", "ES" ]
+			"equipments": ["FR", "ES" ]
 		},
 		{
 			"id": 8737000,
@@ -5976,7 +5976,7 @@
 			"reliability": 1.0,
 			"cost": 320000,
 			"operationCosts": 110,
-			"equipments": [ "CH", "DE", "AT" ]
+			"equipments": [ "DE", "AT" ]
 		},
 		{
 			"id": 80142,


### PR DESCRIPTION
#998 

Bahnstrecken:
- Luzern - Immensee überarbeitet
- Luzern - Rotkreuz - Zug hinzugefügt
- Brugg AG/Lenzburg - Rotkreuz - Immensee ("Aargauische Südbahn") hinzugefügt
- Thalwil - Zug - Arth-Goldau überarbeitet

Fahrzeuge:
- kleine Fixes an Fahrzeugen (CH-Zulassungen entfernt/hinzugefügt)

Tasks:
- Routing 🇨🇭RK und 🇨🇭OTH