### PR TITLE
Fix Koordinaten Südbahn

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -94355,8 +94355,8 @@
 			"name": "Sins",
 			"ril100": "🇨🇭SINS",
 			"group": 5,
-			"x": 253,
-			"y": 756,
+			"x": 254,
+			"y": 762,
 			"platformLength": 214,
 			"platforms": 2,
 			"proj": 3
@@ -94365,8 +94365,8 @@
 			"name": "Oberrüti",
 			"ril100": "🇨🇭OI",
 			"group": 5,
-			"x": 253,
-			"y": 756,
+			"x": 255,
+			"y": 766,
 			"platformLength": 164,
 			"platforms": 2,
 			"proj": 3
@@ -94375,8 +94375,8 @@
 			"name": "Rotkreuz",
 			"ril100": "🇨🇭RK",
 			"group": 2,
-			"x": 253,
-			"y": 756,
+			"x": 258,
+			"y": 770,
 			"platformLength": 458,
 			"platforms": 5,
 			"proj": 3


### PR DESCRIPTION
Koordinaten von in #1020 hinzugefügten Bahnhöfen Sins, Oberrüti und Rotkreuz korrigiert (hatten die gleichen wie Mühlau)