### PR TITLE
Südfrankreich 2/x

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -8928,6 +8928,177 @@
 			]
 		},
 		{
+			"electrified": false,
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"name": "Ligne de Coutras à Tulle",
+			"objects": [
+				{
+					"start": "XFPGX",
+					"end": "🇫🇷O3509770413",
+					"length": 10,
+					"maxSpeed": 160,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "🇫🇷O3509770413",
+					"end": "🇫🇷STK",
+					"length": 6,
+					"maxSpeed": 160,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇫🇷STK",
+					"end": "XFMUS",
+					"length": 18,
+					"maxSpeed": 160,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XFMUS",
+					"end": "🇫🇷MPI",
+					"length": 15,
+					"maxSpeed": 160,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷MPI",
+					"end": "XFCOU",
+					"length": 23,
+					"maxSpeed": 220,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "XFPGX",
+					"end": "🇫🇷72547",
+					"length": 6,
+					"maxSpeed": 160,
+					"twistingFactor": 0.27
+				},
+				{
+					"start": "🇫🇷72547",
+					"end": "🇫🇷NEC",
+					"length": 4,
+					"maxSpeed": 115,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷NEC",
+					"end": "🇫🇷XPH",
+					"length": 4,
+					"maxSpeed": 115,
+					"twistingFactor": 0.03
+				},
+				{
+					"start": "🇫🇷XPH",
+					"end": "🇫🇷THN",
+					"length": 18,
+					"maxSpeed": 115,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷THN",
+					"end": "XFCDT",
+					"length": 13,
+					"maxSpeed": 115,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XFCDT",
+					"end": "🇫🇷O335786652",
+					"length": 5,
+					"maxSpeed": 115,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷O335786652",
+					"end": "🇫🇷LDZ",
+					"length": 5,
+					"maxSpeed": 115,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "🇫🇷LDZ",
+					"end": "XFBLG",
+					"length": 13,
+					"maxSpeed": 120,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "XFBLG",
+					"end": "🇫🇷ABA",
+					"length": 10,
+					"maxSpeed": 115,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷ABA",
+					"end": "🇫🇷CIL",
+					"length": 7,
+					"maxSpeed": 80,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "🇫🇷CIL",
+					"end": "🇫🇷TUL",
+					"length": 7,
+					"maxSpeed": 80,
+					"twistingFactor": 0.29
+				}
+			]
+		},
+		{
+			"electrified": false,
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"objects": [
+				{
+					"start": "🇫🇷TUL",
+					"end": "🇫🇷CZE",
+					"name": "Ligne de Tulle à Meymac",
+					"length": 16,
+					"maxSpeed": 80,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷CZE",
+					"end": "🇫🇷MCE",
+					"name": "Ligne de Tulle à Meymac",
+					"length": 9,
+					"maxSpeed": 75,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "🇫🇷MCE",
+					"end": "🇫🇷EGL",
+					"name": "Ligne de Tulle à Meymac",
+					"length": 9,
+					"maxSpeed": 75,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "🇫🇷EGL",
+					"end": "🇫🇷MYC",
+					"name": "Ligne de Tulle à Meymac",
+					"length": 18,
+					"maxSpeed": 75,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷MYC",
+					"end": "🇫🇷USL",
+					"name": "Ligne du Palais à Eygurande - Merlines",
+					"length": 13,
+					"maxSpeed": 90,
+					"twistingFactor": 0.19
+				}
+			]
+		},
+		{
 			"twistingFactor": 0.1,
 			"maxSpeed": 140,
 			"objects": [
@@ -22482,51 +22653,6 @@
 					"length": 15,
 					"maxSpeed": 160,
 					"twistingFactor": 0.39
-				},
-				{
-					"start": "XFPGX",
-					"end": "🇫🇷O3509770413",
-					"name": "Ligne de Coutras à Tulle",
-					"electrified": false,
-					"length": 10,
-					"maxSpeed": 160,
-					"twistingFactor": 0.28
-				},
-				{
-					"start": "🇫🇷O3509770413",
-					"end": "🇫🇷STK",
-					"name": "Ligne de Coutras à Tulle",
-					"electrified": false,
-					"length": 6,
-					"maxSpeed": 160,
-					"twistingFactor": 0.14
-				},
-				{
-					"start": "🇫🇷STK",
-					"end": "XFMUS",
-					"name": "Ligne de Coutras à Tulle",
-					"electrified": false,
-					"length": 18,
-					"maxSpeed": 160,
-					"twistingFactor": 0.14
-				},
-				{
-					"start": "XFMUS",
-					"end": "🇫🇷MPI",
-					"name": "Ligne de Coutras à Tulle",
-					"electrified": false,
-					"length": 15,
-					"maxSpeed": 160,
-					"twistingFactor": 0.01
-				},
-				{
-					"start": "🇫🇷MPI",
-					"end": "XFCOU",
-					"name": "Ligne de Coutras à Tulle",
-					"electrified": false,
-					"length": 23,
-					"maxSpeed": 220,
-					"twistingFactor": 0.13
 				},
 				{
 					"start": "XFCOU",

--- a/Path.json
+++ b/Path.json
@@ -37290,121 +37290,104 @@
 			"group": 0,
 			"maxSpeed": 160,
 			"twistingFactor": 0.17,
+			"neededEquipments": [
+				"FR"
+			],
 			"objects": [
 				{
 					"start": "🇫🇷VLM",
 					"end": "🇫🇷FRN",
-					"length": 13,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 13
 				},
 				{
 					"start": "🇫🇷FRN",
 					"end": "XFSE",
-					"length": 6,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 6
 				},
 				{
+					"name": "Ligne de Bordeaux à Sète",
 					"start": "XFSE",
 					"end": "🇫🇷78129",
-					"length": 17,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 17
 				},
 				{
+					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷78129",
 					"end": "🇫🇷VA",
-					"length": 9,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 9
 				},
 				{
+					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷VA",
 					"end": "XFBZ",
-					"length": 17,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 17
 				},
 				{
+					"name": "Ligne de Bordeaux à Sète",
 					"start": "XFBZ",
 					"end": "🇫🇷CBS",
-					"length": 7,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 7
 				},
 				{
+					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷CBS",
 					"end": "XFNB",
-					"length": 18,
-					"neededEquipments": [
-						"FR"
-					]
+					"length": 18
 				},
 				{
+					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "XFNB",
 					"end": "🇫🇷PLN",
 					"length": 21,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 150,
 					"twistingFactor": 0.2
 				},
 				{
+					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷PLN",
 					"end": "🇫🇷78108",
 					"length": 10,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 150
 				},
 				{
+					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷78108",
 					"end": "🇫🇷78415",
 					"length": 14,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 150,
 					"twistingFactor": 0.2
 				},
 				{
+					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷78415",
 					"end": "XFRV",
 					"length": 9,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 150
 				},
 				{
+					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "XFRV",
 					"end": "XFPE",
 					"length": 8,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 150
-				},
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 2,
+			"name": "LGV Perpignan-Figueres",
+			"maxSpeed": 350,
+			"twistingFactor": 0.17,
+			"neededEquipments": [
+				"ES",
+				"ETCS"
+			],
+			"objects": [
 				{
 					"start": "XFPE",
 					"end": "XEFI",
-					"name": "LGV Perpignan-Figueres",
-					"group": 2,
-					"length": 54,
-					"neededEquipments": [
-						"ES",
-						"ETCS"
-					],
-					"maxSpeed": 350
+					"length": 54
 				}
 			]
 		},
@@ -45003,6 +44986,7 @@
 			"electrified": true,
 			"group": 0,
 			"maxSpeed": 160,
+			"name": "Ligne de Bordeaux à Sète",
 			"neededEquipments": [
 				"FR"
 			],

--- a/Path.json
+++ b/Path.json
@@ -36049,11 +36049,11 @@
 			"neededEquipments": [
 				"FR"
 			],
+			"electrified": true,
 			"objects": [
 				{
 					"start": "🇫🇷NEU",
 					"end": "🇫🇷SFC",
-					"electrified": true,
 					"length": 18,
 					"maxSpeed": 80,
 					"twistingFactor": 0.38
@@ -36061,7 +36061,6 @@
 				{
 					"start": "🇫🇷SFC",
 					"end": "🇫🇷SYH",
-					"electrified": true,
 					"length": 36,
 					"maxSpeed": 90,
 					"twistingFactor": 0.34
@@ -36069,7 +36068,6 @@
 				{
 					"start": "🇫🇷SYH",
 					"end": "🇫🇷AAU",
-					"electrified": true,
 					"length": 10,
 					"maxSpeed": 60,
 					"twistingFactor": 0.29
@@ -36077,7 +36075,6 @@
 				{
 					"start": "🇫🇷AAU",
 					"end": "🇫🇷MVJ",
-					"electrified": true,
 					"length": 21,
 					"maxSpeed": 60,
 					"twistingFactor": 0.21
@@ -36085,7 +36082,6 @@
 				{
 					"start": "🇫🇷MVJ",
 					"end": "🇫🇷CAC",
-					"electrified": true,
 					"length": 2,
 					"maxSpeed": 50,
 					"twistingFactor": 0.16
@@ -36093,7 +36089,6 @@
 				{
 					"start": "🇫🇷CAC",
 					"end": "🇫🇷LMR",
-					"electrified": false,
 					"length": 2,
 					"maxSpeed": 60,
 					"twistingFactor": 0.24
@@ -36101,7 +36096,6 @@
 				{
 					"start": "🇫🇷LMR",
 					"end": "🇫🇷BAA",
-					"electrified": true,
 					"length": 9,
 					"maxSpeed": 60,
 					"twistingFactor": 0.28
@@ -36109,7 +36103,6 @@
 				{
 					"start": "🇫🇷BAA",
 					"end": "🇫🇷CNT",
-					"electrified": true,
 					"length": 12,
 					"maxSpeed": 85,
 					"twistingFactor": 0.28
@@ -36117,7 +36110,6 @@
 				{
 					"start": "🇫🇷CNT",
 					"end": "🇫🇷SVC",
-					"electrified": true,
 					"length": 13,
 					"maxSpeed": 85,
 					"twistingFactor": 0.33
@@ -36125,7 +36117,6 @@
 				{
 					"start": "🇫🇷SVC",
 					"end": "🇫🇷MAU",
-					"electrified": true,
 					"length": 30,
 					"maxSpeed": 80,
 					"twistingFactor": 0.31
@@ -36133,7 +36124,6 @@
 				{
 					"start": "🇫🇷MAU",
 					"end": "🇫🇷SDU",
-					"electrified": true,
 					"length": 11,
 					"maxSpeed": 80,
 					"twistingFactor": 0.39
@@ -36141,7 +36131,6 @@
 				{
 					"start": "🇫🇷SDU",
 					"end": "🇫🇷SDO",
-					"electrified": true,
 					"length": 6,
 					"maxSpeed": 80,
 					"twistingFactor": 0.18
@@ -36149,7 +36138,6 @@
 				{
 					"start": "🇫🇷SDO",
 					"end": "🇫🇷TEO",
-					"electrified": true,
 					"length": 7,
 					"maxSpeed": 80,
 					"twistingFactor": 0.23
@@ -36157,7 +36145,6 @@
 				{
 					"start": "🇫🇷TEO",
 					"end": "🇫🇷MNP",
-					"electrified": true,
 					"length": 16,
 					"maxSpeed": 75,
 					"twistingFactor": 0.32
@@ -36165,7 +36152,6 @@
 				{
 					"start": "🇫🇷MNP",
 					"end": "🇫🇷COQ",
-					"electrified": true,
 					"length": 7,
 					"maxSpeed": 80,
 					"twistingFactor": 0.16
@@ -36173,7 +36159,6 @@
 				{
 					"start": "🇫🇷COQ",
 					"end": "🇫🇷KBI",
-					"electrified": true,
 					"length": 4,
 					"maxSpeed": 80,
 					"twistingFactor": 0.21
@@ -36181,7 +36166,6 @@
 				{
 					"start": "🇫🇷KBI",
 					"end": "🇫🇷LKH",
-					"electrified": true,
 					"length": 8,
 					"maxSpeed": 80,
 					"twistingFactor": 0.16
@@ -36189,7 +36173,6 @@
 				{
 					"start": "🇫🇷LKH",
 					"end": "🇫🇷LBD",
-					"electrified": true,
 					"length": 3,
 					"maxSpeed": 80,
 					"twistingFactor": 0.19
@@ -36197,7 +36180,6 @@
 				{
 					"start": "🇫🇷LBD",
 					"end": "🇫🇷BED",
-					"electrified": true,
 					"length": 10,
 					"maxSpeed": 85,
 					"twistingFactor": 0.29
@@ -36205,7 +36187,6 @@
 				{
 					"start": "🇫🇷BED",
 					"end": "🇫🇷MGA",
-					"electrified": true,
 					"length": 24,
 					"maxSpeed": 105,
 					"twistingFactor": 0.39
@@ -36213,7 +36194,6 @@
 				{
 					"start": "🇫🇷MGA",
 					"end": "XFBZ",
-					"electrified": true,
 					"length": 18,
 					"maxSpeed": 110,
 					"twistingFactor": 0.33

--- a/Path.json
+++ b/Path.json
@@ -30035,14 +30035,15 @@
 		{
 			"electrified": true,
 			"group": 0,
+			"name": "Ligne de Bordeaux à Irun",
+			"neededEquipments": [
+				"FR"
+			],
 			"objects": [
 				{
 					"start": "XFBJ",
 					"end": "🇫🇷GAZ",
 					"length": 13,
-					"neededEquipments": [
-						"FR"
-					],
 					"twistingFactor": 0.1,
 					"maxSpeed": 160
 				},
@@ -30050,9 +30051,6 @@
 					"start": "🇫🇷GAZ",
 					"end": "🇫🇷MCP",
 					"length": 15,
-					"neededEquipments": [
-						"FR"
-					],
 					"twistingFactor": 0.01,
 					"maxSpeed": 160
 				},
@@ -30060,9 +30058,6 @@
 					"start": "🇫🇷MCP",
 					"end": "🇫🇷FAT",
 					"length": 10,
-					"neededEquipments": [
-						"FR"
-					],
 					"twistingFactor": 0.01,
 					"maxSpeed": 160
 				},
@@ -30070,9 +30065,6 @@
 					"start": "🇫🇷FAT",
 					"end": "🇫🇷YXC",
 					"length": 36,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 200,
 					"twistingFactor": 0.1
 				},
@@ -30080,9 +30072,6 @@
 					"start": "🇫🇷YXC",
 					"end": "🇫🇷LBH",
 					"length": 14,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 200,
 					"twistingFactor": 0.1
 				},
@@ -30090,9 +30079,6 @@
 					"start": "🇫🇷LBH",
 					"end": "XFMCX",
 					"length": 19,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 160,
 					"twistingFactor": 0.01
 				},
@@ -30100,9 +30086,6 @@
 					"start": "XFMCX",
 					"end": "🇫🇷67312",
 					"length": 25,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 160,
 					"twistingFactor": 0.16
 				},
@@ -30110,9 +30093,6 @@
 					"start": "🇫🇷67312",
 					"end": "XFDX",
 					"length": 14,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 160,
 					"twistingFactor": 0.12
 				},
@@ -30120,9 +30100,6 @@
 					"start": "XFDX",
 					"end": "🇫🇷SQB",
 					"length": 14,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 130,
 					"twistingFactor": 0.2
 				},
@@ -30130,9 +30107,6 @@
 					"start": "🇫🇷SQB",
 					"end": "🇫🇷SVT",
 					"length": 10,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 130,
 					"twistingFactor": 0.2
 				},
@@ -30140,9 +30114,6 @@
 					"start": "🇫🇷SVT",
 					"end": "🇫🇷LBN",
 					"length": 12,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 140,
 					"twistingFactor": 0.1
 				},
@@ -30150,9 +30121,6 @@
 					"start": "🇫🇷LBN",
 					"end": "XFBY",
 					"length": 13,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 140,
 					"twistingFactor": 0.17
 				},
@@ -30160,9 +30128,6 @@
 					"start": "XFBY",
 					"end": "XFBR",
 					"length": 9,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 100,
 					"twistingFactor": 0.2
 				},
@@ -30170,9 +30135,6 @@
 					"start": "XFBR",
 					"end": "XFHE",
 					"length": 25,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 100,
 					"twistingFactor": 0.2
 				},
@@ -30180,9 +30142,6 @@
 					"start": "XFHE",
 					"end": "XEIR",
 					"length": 2,
-					"neededEquipments": [
-						"FR"
-					],
 					"maxSpeed": 30,
 					"twistingFactor": 0.1
 				}

--- a/Path.json
+++ b/Path.json
@@ -72208,6 +72208,201 @@
 			]
 		},
 		{
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"electrified": false,
+			"name": "Ligne de Figeac à Arvant",
+			"objects": [
+				{
+					"start": "🇫🇷FIG",
+					"end": "🇫🇷BAG",
+					"length": 13,
+					"maxSpeed": 70,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "🇫🇷BAG",
+					"end": "🇫🇷MRS",
+					"length": 5,
+					"maxSpeed": 75,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇫🇷MRS",
+					"end": "🇫🇷BCL",
+					"length": 11,
+					"maxSpeed": 55,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇫🇷BCL",
+					"end": "🇫🇷LRG",
+					"length": 8,
+					"maxSpeed": 55,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "🇫🇷LRG",
+					"end": "🇫🇷PEK",
+					"length": 3,
+					"maxSpeed": 55,
+					"twistingFactor": 0.02
+				},
+				{
+					"start": "🇫🇷PEK",
+					"end": "🇫🇷WCV",
+					"length": 4,
+					"maxSpeed": 55,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷WCV",
+					"end": "🇫🇷O1817739379",
+					"length": 2,
+					"maxSpeed": 75,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷O1817739379",
+					"end": "🇫🇷YTC",
+					"length": 6,
+					"maxSpeed": 100,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷YTC",
+					"end": "🇫🇷AUC",
+					"length": 7,
+					"maxSpeed": 100,
+					"twistingFactor": 0.37
+				},
+				{
+					"start": "🇫🇷AUC",
+					"end": "🇫🇷VCM",
+					"length": 19,
+					"maxSpeed": 120,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷VCM",
+					"end": "🇫🇷LLN",
+					"length": 17,
+					"maxSpeed": 120,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "🇫🇷LLN",
+					"end": "🇫🇷MUR",
+					"length": 10,
+					"maxSpeed": 90,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "🇫🇷MUR",
+					"end": "🇫🇷NEU",
+					"length": 9,
+					"maxSpeed": 90,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "🇫🇷NEU",
+					"end": "🇫🇷MIA",
+					"length": 25,
+					"maxSpeed": 90,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "🇫🇷MIA",
+					"end": "XFARV",
+					"length": 23,
+					"maxSpeed": 90,
+					"twistingFactor": 0.4
+				}
+			]
+		},
+		{
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"electrified": false,
+			"name": "Ligne de Saint-Germain-des-Fossés à Nîmes-Courbessac",
+			"objects": [
+				{
+					"start": "XFARV",
+					"end": "🇫🇷BLM",
+					"length": 5,
+					"maxSpeed": 110,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "🇫🇷BLM",
+					"end": "🇫🇷BCZ",
+					"length": 9,
+					"maxSpeed": 140,
+					"twistingFactor": 0.32
+				},
+				{
+					"start": "🇫🇷BCZ",
+					"end": "🇫🇷ISS",
+					"length": 8,
+					"maxSpeed": 140,
+					"twistingFactor": 0.05
+				},
+				{
+					"start": "🇫🇷ISS",
+					"end": "🇫🇷PCC",
+					"length": 10,
+					"maxSpeed": 140,
+					"twistingFactor": 0.32
+				},
+				{
+					"start": "🇫🇷PCC",
+					"end": "🇫🇷VLC",
+					"length": 6,
+					"maxSpeed": 85,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷VLC",
+					"end": "🇫🇷MVY",
+					"length": 3,
+					"maxSpeed": 100,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "🇫🇷MVY",
+					"end": "🇫🇷CZJ",
+					"length": 4,
+					"maxSpeed": 140,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "🇫🇷CZJ",
+					"end": "XFSLC",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "XFSLC",
+					"end": "🇫🇷O8309273399",
+					"length": 4,
+					"maxSpeed": 140,
+					"twistingFactor": 0.05
+				},
+				{
+					"start": "🇫🇷O8309273399",
+					"end": "XFCLE",
+					"length": 3,
+					"maxSpeed": 140,
+					"twistingFactor": 0.29
+				}
+			]
+		},
+		{
 			"maxSpeed": 160,
 			"electrified": true,
 			"group": 0,

--- a/Path.json
+++ b/Path.json
@@ -9055,11 +9055,11 @@
 			"neededEquipments": [
 				"FR"
 			],
+			"name": "Ligne de Tulle à Meymac",
 			"objects": [
 				{
 					"start": "🇫🇷TUL",
 					"end": "🇫🇷CZE",
-					"name": "Ligne de Tulle à Meymac",
 					"length": 16,
 					"maxSpeed": 80,
 					"twistingFactor": 0.39
@@ -9067,7 +9067,6 @@
 				{
 					"start": "🇫🇷CZE",
 					"end": "🇫🇷MCE",
-					"name": "Ligne de Tulle à Meymac",
 					"length": 9,
 					"maxSpeed": 75,
 					"twistingFactor": 0.2
@@ -9075,7 +9074,6 @@
 				{
 					"start": "🇫🇷MCE",
 					"end": "🇫🇷EGL",
-					"name": "Ligne de Tulle à Meymac",
 					"length": 9,
 					"maxSpeed": 75,
 					"twistingFactor": 0.18
@@ -9083,7 +9081,6 @@
 				{
 					"start": "🇫🇷EGL",
 					"end": "🇫🇷MYC",
-					"name": "Ligne de Tulle à Meymac",
 					"length": 18,
 					"maxSpeed": 75,
 					"twistingFactor": 0.29
@@ -22590,12 +22587,12 @@
 			"neededEquipments": [
 				"FR"
 			],
+			"name": "Ligne de Limoges-Bénédictins à Périgueux",
+			"electrified": false,
 			"objects": [
 				{
 					"start": "🇫🇷LIM",
 					"end": "🇫🇷AGF",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 8,
 					"maxSpeed": 110,
 					"twistingFactor": 0.13
@@ -22603,8 +22600,6 @@
 				{
 					"start": "🇫🇷AGF",
 					"end": "🇫🇷NNF",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 11,
 					"maxSpeed": 110,
 					"twistingFactor": 0.29
@@ -22612,8 +22607,6 @@
 				{
 					"start": "🇫🇷NNF",
 					"end": "🇫🇷BGA",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 17,
 					"maxSpeed": 110,
 					"twistingFactor": 0.26
@@ -22621,8 +22614,6 @@
 				{
 					"start": "🇫🇷BGA",
 					"end": "🇫🇷LCQ",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 9,
 					"maxSpeed": 140,
 					"twistingFactor": 0.29
@@ -22630,8 +22621,6 @@
 				{
 					"start": "🇫🇷LCQ",
 					"end": "🇫🇷TIV",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 14,
 					"maxSpeed": 140,
 					"twistingFactor": 0.14
@@ -22639,8 +22628,6 @@
 				{
 					"start": "🇫🇷TIV",
 					"end": "🇫🇷AGA",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 20,
 					"maxSpeed": 140,
 					"twistingFactor": 0.13
@@ -22648,17 +22635,23 @@
 				{
 					"start": "🇫🇷AGA",
 					"end": "XFPGX",
-					"name": "Ligne de Limoges-Bénédictins à Périgueux",
-					"electrified": false,
 					"length": 15,
 					"maxSpeed": 160,
 					"twistingFactor": 0.39
-				},
+				}
+			]
+		},
+		{
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"name": "Ligne de Paris-Austerlitz à Bordeaux-Saint-Jean",
+			"electrified": true,
+			"objects": [
 				{
 					"start": "XFCOU",
 					"end": "🇫🇷LIB",
-					"name": "Ligne de Paris-Austerlitz à Bordeaux-Saint-Jean",
-					"electrified": true,
 					"length": 16,
 					"maxSpeed": 220,
 					"twistingFactor": 0.11
@@ -22666,8 +22659,6 @@
 				{
 					"start": "🇫🇷LIB",
 					"end": "🇫🇷VYR",
-					"name": "Ligne de Paris-Austerlitz à Bordeaux-Saint-Jean",
-					"electrified": true,
 					"length": 7,
 					"maxSpeed": 220,
 					"twistingFactor": 0.3
@@ -22675,8 +22666,6 @@
 				{
 					"start": "🇫🇷VYR",
 					"end": "XFBJ",
-					"name": "Ligne de Paris-Austerlitz à Bordeaux-Saint-Jean",
-					"electrified": true,
 					"length": 27,
 					"maxSpeed": 220,
 					"twistingFactor": 0.39

--- a/Path.json
+++ b/Path.json
@@ -12449,7 +12449,7 @@
 					"maxSpeed": 200
 				},
 				{
-					"name":"Ligne de Saint-Germain-des-Fossés à Darsac",
+					"name": "Ligne de Saint-Germain-des-Fossés à Darsac",
 					"start": "XFSGF",
 					"end": "🇫🇷VHY",
 					"length": 10,

--- a/Path.json
+++ b/Path.json
@@ -19839,6 +19839,191 @@
 			]
 		},
 		{
+			"name": "Ligne de Brive-la-Gaillarde à Toulouse-Matabiau via Capdenac",
+			"electrified": false,
+			"neededEquipments": [
+				"FR"
+			],
+			"group": 0,
+			"objects": [
+				{
+					"start": "XFTM",
+					"end": "🇫🇷MTB",
+					"length": 7,
+					"maxSpeed": 140,
+					"twistingFactor": 0.26
+				},
+				{
+					"start": "🇫🇷MTB",
+					"end": "🇫🇷GAG",
+					"length": 7,
+					"maxSpeed": 110,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷GAG",
+					"end": "🇫🇷MCL",
+					"length": 4,
+					"maxSpeed": 110,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "🇫🇷MCL",
+					"end": "🇫🇷O11016655586",
+					"length": 4,
+					"maxSpeed": 110,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "🇫🇷O11016655586",
+					"end": "🇫🇷SST",
+					"length": 5,
+					"maxSpeed": 160,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷SST",
+					"end": "🇫🇷O1119769298",
+					"length": 6,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "🇫🇷O1119769298",
+					"end": "🇫🇷LSU",
+					"length": 7,
+					"maxSpeed": 130,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "🇫🇷LSU",
+					"end": "🇫🇷GAI",
+					"length": 8,
+					"maxSpeed": 130,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷GAI",
+					"end": "🇫🇷TES",
+					"length": 3,
+					"maxSpeed": 130,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷TES",
+					"end": "🇫🇷VDC",
+					"length": 19,
+					"maxSpeed": 130,
+					"twistingFactor": 0.32
+				},
+				{
+					"start": "🇫🇷VDC",
+					"end": "🇫🇷LEX",
+					"length": 10,
+					"maxSpeed": 85,
+					"twistingFactor": 0.36
+				},
+				{
+					"start": "🇫🇷LEX",
+					"end": "🇫🇷LPB",
+					"length": 8,
+					"maxSpeed": 85,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "🇫🇷LPB",
+					"end": "🇫🇷NAJ",
+					"length": 10,
+					"maxSpeed": 85,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇫🇷NAJ",
+					"end": "🇫🇷VRW",
+					"length": 16,
+					"maxSpeed": 80,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷VRW",
+					"end": "🇫🇷SIR",
+					"length": 15,
+					"maxSpeed": 85,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷SIR",
+					"end": "🇫🇷CDC",
+					"length": 13,
+					"maxSpeed": 80,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇫🇷CDC",
+					"end": "🇫🇷FIG",
+					"length": 5,
+					"maxSpeed": 80,
+					"twistingFactor": 0.38
+				},
+				{
+					"start": "🇫🇷FIG",
+					"end": "🇫🇷AER",
+					"group": 1,
+					"length": 18,
+					"maxSpeed": 110,
+					"twistingFactor": 0.31
+				},
+				{
+					"start": "🇫🇷AER",
+					"end": "🇫🇷GRT",
+					"group": 1,
+					"length": 16,
+					"maxSpeed": 140,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇫🇷GRT",
+					"end": "🇫🇷RAP",
+					"group": 1,
+					"length": 7,
+					"maxSpeed": 105,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇫🇷RAP",
+					"end": "🇫🇷SDM",
+					"group": 1,
+					"length": 18,
+					"maxSpeed": 105,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷SDM",
+					"end": "🇫🇷O3423253720",
+					"group": 1,
+					"length": 6,
+					"maxSpeed": 80,
+					"twistingFactor": 0.07
+				},
+				{
+					"start": "🇫🇷O3423253720",
+					"end": "🇫🇷TUR",
+					"group": 1,
+					"length": 5,
+					"maxSpeed": 80,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "🇫🇷TUR",
+					"end": "XFBLG",
+					"group": 1,
+					"length": 15,
+					"maxSpeed": 120,
+					"twistingFactor": 0.21
+				}
+			]
+		},
+		{
 			"group": 0,
 			"neededEquipments": [
 				"MD",

--- a/Path.json
+++ b/Path.json
@@ -12449,6 +12449,7 @@
 					"maxSpeed": 200
 				},
 				{
+					"name":"Ligne de Saint-Germain-des-Fossés à Darsac",
 					"start": "XFSGF",
 					"end": "🇫🇷VHY",
 					"length": 10,
@@ -12456,6 +12457,7 @@
 					"maxSpeed": 110
 				},
 				{
+					"name": "Ligne de Vichy à Riom",
 					"start": "🇫🇷VHY",
 					"end": "🇫🇷RIO",
 					"length": 40,
@@ -12463,6 +12465,7 @@
 					"maxSpeed": 140
 				},
 				{
+					"name": "Ligne de Saint-Germain-des-Fossés à Nîmes-Courbessac",
 					"start": "🇫🇷RIO",
 					"end": "XFCLE",
 					"length": 13,

--- a/Path.json
+++ b/Path.json
@@ -36044,6 +36044,183 @@
 			]
 		},
 		{
+			"name": "Ligne de Béziers à Neussargues",
+			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"objects": [
+				{
+					"start": "🇫🇷NEU",
+					"end": "🇫🇷SFC",
+					"electrified": true,
+					"length": 18,
+					"maxSpeed": 80,
+					"twistingFactor": 0.38
+				},
+				{
+					"start": "🇫🇷SFC",
+					"end": "🇫🇷SYH",
+					"electrified": true,
+					"length": 36,
+					"maxSpeed": 90,
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "🇫🇷SYH",
+					"end": "🇫🇷AAU",
+					"electrified": true,
+					"length": 10,
+					"maxSpeed": 60,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷AAU",
+					"end": "🇫🇷MVJ",
+					"electrified": true,
+					"length": 21,
+					"maxSpeed": 60,
+					"twistingFactor": 0.21
+				},
+				{
+					"start": "🇫🇷MVJ",
+					"end": "🇫🇷CAC",
+					"electrified": true,
+					"length": 2,
+					"maxSpeed": 50,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇫🇷CAC",
+					"end": "🇫🇷LMR",
+					"electrified": false,
+					"length": 2,
+					"maxSpeed": 60,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "🇫🇷LMR",
+					"end": "🇫🇷BAA",
+					"electrified": true,
+					"length": 9,
+					"maxSpeed": 60,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "🇫🇷BAA",
+					"end": "🇫🇷CNT",
+					"electrified": true,
+					"length": 12,
+					"maxSpeed": 85,
+					"twistingFactor": 0.28
+				},
+				{
+					"start": "🇫🇷CNT",
+					"end": "🇫🇷SVC",
+					"electrified": true,
+					"length": 13,
+					"maxSpeed": 85,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "🇫🇷SVC",
+					"end": "🇫🇷MAU",
+					"electrified": true,
+					"length": 30,
+					"maxSpeed": 80,
+					"twistingFactor": 0.31
+				},
+				{
+					"start": "🇫🇷MAU",
+					"end": "🇫🇷SDU",
+					"electrified": true,
+					"length": 11,
+					"maxSpeed": 80,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷SDU",
+					"end": "🇫🇷SDO",
+					"electrified": true,
+					"length": 6,
+					"maxSpeed": 80,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "🇫🇷SDO",
+					"end": "🇫🇷TEO",
+					"electrified": true,
+					"length": 7,
+					"maxSpeed": 80,
+					"twistingFactor": 0.23
+				},
+				{
+					"start": "🇫🇷TEO",
+					"end": "🇫🇷MNP",
+					"electrified": true,
+					"length": 16,
+					"maxSpeed": 75,
+					"twistingFactor": 0.32
+				},
+				{
+					"start": "🇫🇷MNP",
+					"end": "🇫🇷COQ",
+					"electrified": true,
+					"length": 7,
+					"maxSpeed": 80,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇫🇷COQ",
+					"end": "🇫🇷KBI",
+					"electrified": true,
+					"length": 4,
+					"maxSpeed": 80,
+					"twistingFactor": 0.21
+				},
+				{
+					"start": "🇫🇷KBI",
+					"end": "🇫🇷LKH",
+					"electrified": true,
+					"length": 8,
+					"maxSpeed": 80,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇫🇷LKH",
+					"end": "🇫🇷LBD",
+					"electrified": true,
+					"length": 3,
+					"maxSpeed": 80,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷LBD",
+					"end": "🇫🇷BED",
+					"electrified": true,
+					"length": 10,
+					"maxSpeed": 85,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷BED",
+					"end": "🇫🇷MGA",
+					"electrified": true,
+					"length": 24,
+					"maxSpeed": 105,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷MGA",
+					"end": "XFBZ",
+					"electrified": true,
+					"length": 18,
+					"maxSpeed": 110,
+					"twistingFactor": 0.33
+				}
+			]
+		},
+		{
 			"electrified": false,
 			"group": 1,
 			"twistingFactor": 0.25,

--- a/Station.json
+++ b/Station.json
@@ -65159,7 +65159,7 @@
 		{
 			"name": "Pers",
 			"ril100": "🇫🇷PEK",
-			"group": 2,
+			"group": 5,
 			"x": -616,
 			"y": 1150,
 			"platformLength": 85,
@@ -65169,7 +65169,7 @@
 		{
 			"name": "Lacapelle-Viescamp",
 			"ril100": "🇫🇷WCV",
-			"group": 2,
+			"group": 5,
 			"x": -612,
 			"y": 1144,
 			"platformLength": 73,
@@ -65317,7 +65317,7 @@
 		{
 			"name": "Les Martres-de-Veyre",
 			"ril100": "🇫🇷MVY",
-			"group": 2,
+			"group": 5,
 			"x": -477,
 			"y": 1015,
 			"platformLength": 217,
@@ -65327,7 +65327,7 @@
 		{
 			"name": "Le Cendre—Orcet",
 			"ril100": "🇫🇷CZJ",
-			"group": 2,
+			"group": 5,
 			"x": -477,
 			"y": 1009,
 			"platformLength": 192,
@@ -65337,7 +65337,7 @@
 		{
 			"name": "Sarlieve-Cournon",
 			"ril100": "XFSLC",
-			"group": 2,
+			"group": 5,
 			"x": -480,
 			"y": 1006,
 			"platformLength": 208,

--- a/Station.json
+++ b/Station.json
@@ -65117,6 +65117,244 @@
 			"platforms": 10
 		},
 		{
+			"name": "Bagnac",
+			"ril100": "🇫🇷BAG",
+			"group": 2,
+			"x": -629,
+			"y": 1187,
+			"platformLength": 90,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Maurs",
+			"ril100": "🇫🇷MRS",
+			"group": 2,
+			"x": -623,
+			"y": 1180,
+			"platformLength": 102,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Boisset",
+			"ril100": "🇫🇷BCL",
+			"group": 2,
+			"x": -615,
+			"y": 1167,
+			"platformLength": 154,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Le Rouget",
+			"ril100": "🇫🇷LRG",
+			"group": 2,
+			"x": -617,
+			"y": 1155,
+			"platformLength": 123,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Pers",
+			"ril100": "🇫🇷PEK",
+			"group": 2,
+			"x": -616,
+			"y": 1150,
+			"platformLength": 85,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Lacapelle-Viescamp",
+			"ril100": "🇫🇷WCV",
+			"group": 2,
+			"x": -612,
+			"y": 1144,
+			"platformLength": 73,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Viescamp-sous-Jallès",
+			"ril100": "🇫🇷O1817739379",
+			"group": 4,
+			"x": -609,
+			"y": 1145,
+			"proj": 3
+		},
+		{
+			"name": "Ytrac",
+			"ril100": "🇫🇷YTC",
+			"group": 2,
+			"x": -598,
+			"y": 1146,
+			"platformLength": 102,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Aurillac",
+			"ril100": "🇫🇷AUC",
+			"group": 2,
+			"x": -588,
+			"y": 1144,
+			"platformLength": 254,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Vic-sur-Cère",
+			"ril100": "🇫🇷VCM",
+			"group": 2,
+			"x": -560,
+			"y": 1135,
+			"platformLength": 203,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Le Lioran",
+			"ril100": "🇫🇷LLN",
+			"group": 2,
+			"x": -542,
+			"y": 1115,
+			"platformLength": 151,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Murat",
+			"ril100": "🇫🇷MUR",
+			"group": 2,
+			"x": -526,
+			"y": 1112,
+			"platformLength": 187,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Neussargues",
+			"ril100": "🇫🇷NEU",
+			"group": 2,
+			"x": -510,
+			"y": 1110,
+			"platformLength": 377,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Massiac-Blesle",
+			"ril100": "🇫🇷MIA",
+			"group": 2,
+			"x": -479,
+			"y": 1088,
+			"platformLength": 354,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Arvant",
+			"ril100": "XFARV",
+			"group": 2,
+			"x": -462,
+			"y": 1069,
+			"platformLength": 338,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Brassac-les-Mines—Ste-Florine",
+			"ril100": "🇫🇷BLM",
+			"group": 2,
+			"x": -459,
+			"y": 1061,
+			"platformLength": 326,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Le Breuil-sur-Couze",
+			"ril100": "🇫🇷BCZ",
+			"group": 2,
+			"x": -469,
+			"y": 1052,
+			"platformLength": 178,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Issoire",
+			"ril100": "🇫🇷ISS",
+			"group": 2,
+			"x": -469,
+			"y": 1039,
+			"platformLength": 388,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Parent—Coudes—Champeix",
+			"ril100": "🇫🇷PCC",
+			"group": 2,
+			"x": -474,
+			"y": 1027,
+			"platformLength": 181,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Vic-le-Comte",
+			"ril100": "🇫🇷VLC",
+			"group": 2,
+			"x": -475,
+			"y": 1018,
+			"platformLength": 232,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Les Martres-de-Veyre",
+			"ril100": "🇫🇷MVY",
+			"group": 2,
+			"x": -477,
+			"y": 1015,
+			"platformLength": 217,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Le Cendre—Orcet",
+			"ril100": "🇫🇷CZJ",
+			"group": 2,
+			"x": -477,
+			"y": 1009,
+			"platformLength": 192,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Sarlieve-Cournon",
+			"ril100": "XFSLC",
+			"group": 2,
+			"x": -480,
+			"y": 1006,
+			"platformLength": 208,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Clermont - La Pardieu",
+			"ril100": "🇫🇷O8309273399",
+			"group": 5,
+			"x": -485,
+			"y": 1001,
+			"platformLength": 173,
+			"platforms": 9,
+			"proj": 3
+		},
+		{
 			"name": "Želenice nad Bílinou",
 			"ril100": "🇨🇿5454549",
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -26422,6 +26422,148 @@
 			"platformLength": 200
 		},
 		{
+			"name": "Boulazac Isle Manoire",
+			"ril100": "🇫🇷72547",
+			"group": 2,
+			"x": -820,
+			"y": 1102,
+			"proj": 3
+		},
+		{
+			"name": "Niversac",
+			"ril100": "🇫🇷NEC",
+			"group": 2,
+			"x": -816,
+			"y": 1107,
+			"proj": 3
+		},
+		{
+			"name": "St-Pierre-de-Chignac",
+			"ril100": "🇫🇷XPH",
+			"group": 2,
+			"x": -809,
+			"y": 1110,
+			"proj": 3
+		},
+		{
+			"name": "Thenon",
+			"ril100": "🇫🇷THN",
+			"group": 2,
+			"x": -779,
+			"y": 1104,
+			"platformLength": 105,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Condat-le-Lardin",
+			"ril100": "XFCDT",
+			"group": 2,
+			"x": -757,
+			"y": 1109,
+			"platformLength": 160,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Terrasson - Lavilledieu",
+			"ril100": "🇫🇷O335786652",
+			"group": 2,
+			"x": -746,
+			"y": 1108,
+			"proj": 3
+		},
+		{
+			"name": "La Rivière-de-Mansac",
+			"ril100": "🇫🇷LDZ",
+			"group": 2,
+			"x": -737,
+			"y": 1107,
+			"platformLength": 93,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Aubazine—St-Hilaire",
+			"ril100": "🇫🇷ABA",
+			"group": 2,
+			"x": -698,
+			"y": 1100,
+			"platformLength": 96,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Cornil",
+			"ril100": "🇫🇷CIL",
+			"group": 2,
+			"x": -690,
+			"y": 1094,
+			"platformLength": 92,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Tulle",
+			"ril100": "🇫🇷TUL",
+			"group": 2,
+			"x": -681,
+			"y": 1087,
+			"platformLength": 246,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Corrèze",
+			"ril100": "🇫🇷CZE",
+			"group": 2,
+			"x": -663,
+			"y": 1075,
+			"platformLength": 165,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Montaignac-St-Hippolyte",
+			"ril100": "🇫🇷MCE",
+			"group": 2,
+			"x": -649,
+			"y": 1071,
+			"platformLength": 90,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Égletons",
+			"ril100": "🇫🇷EGL",
+			"group": 1,
+			"x": -637,
+			"y": 1063,
+			"platformLength": 175,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Meymac",
+			"ril100": "🇫🇷MYC",
+			"group": 2,
+			"x": -622,
+			"y": 1041,
+			"platformLength": 180,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Ussel",
+			"ril100": "🇫🇷USL",
+			"group": 2,
+			"x": -601,
+			"y": 1037,
+			"platformLength": 224,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
 			"name": "Głogów Wróblin",
 			"ril100": "🇵🇱O11020175281",
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -34786,7 +34786,7 @@
 			"proj": 3
 		},
 		{
-			"name": "St-Sulpice",
+			"name": "St-Sulpice-sur-Tarn",
 			"ril100": "🇫🇷SST",
 			"group": 2,
 			"x": -702,
@@ -34948,7 +34948,7 @@
 			"proj": 3
 		},
 		{
-			"name": "Les Quatre-Routes",
+			"name": "Les Quatre-Routes-du-Lot",
 			"ril100": "🇫🇷O3423253720",
 			"group": 5,
 			"x": -699,
@@ -57390,7 +57390,7 @@
 			"proj": 3
 		},
 		{
-			"name": "Chirac",
+			"name": "Chirac (Lozère)",
 			"ril100": "🇫🇷CAC",
 			"group": 2,
 			"x": -474,

--- a/Station.json
+++ b/Station.json
@@ -57277,6 +57277,172 @@
 			"proj": 3
 		},
 		{
+			"name": "St-Flour—Chaudes-Aigues",
+			"ril100": "🇫🇷SFC",
+			"group": 2,
+			"x": -493,
+			"y": 1125,
+			"platformLength": 241,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "St-Chély-d'Apcher",
+			"ril100": "🇫🇷SYH",
+			"group": 2,
+			"x": -471,
+			"y": 1164,
+			"proj": 3
+		},
+		{
+			"name": "Aumont-Aubrac",
+			"ril100": "🇫🇷AAU",
+			"group": 2,
+			"x": -470,
+			"y": 1178,
+			"proj": 3
+		},
+		{
+			"name": "Marvejols",
+			"ril100": "🇫🇷MVJ",
+			"group": 2,
+			"x": -471,
+			"y": 1208,
+			"proj": 3
+		},
+		{
+			"name": "Chirac",
+			"ril100": "🇫🇷CAC",
+			"group": 2,
+			"x": -474,
+			"y": 1211,
+			"proj": 3
+		},
+		{
+			"name": "Le Monastier",
+			"ril100": "🇫🇷LMR",
+			"group": 2,
+			"x": -475,
+			"y": 1214,
+			"platformLength": 145,
+			"platforms": 10,
+			"proj": 3
+		},
+		{
+			"name": "Banassac—La Canourgue",
+			"ril100": "🇫🇷BAA",
+			"group": 2,
+			"x": -484,
+			"y": 1224,
+			"proj": 3
+		},
+		{
+			"name": "Campagnac—St-Geniez",
+			"ril100": "🇫🇷CNT",
+			"group": 2,
+			"x": -502,
+			"y": 1228,
+			"proj": 3
+		},
+		{
+			"name": "Séverac-le-Château",
+			"ril100": "🇫🇷SVC",
+			"group": 2,
+			"x": -504,
+			"y": 1245,
+			"proj": 3
+		},
+		{
+			"name": "Millau",
+			"ril100": "🇫🇷MAU",
+			"group": 2,
+			"x": -503,
+			"y": 1283,
+			"proj": 3
+		},
+		{
+			"name": "St-Georges-de-Luzençon",
+			"ril100": "🇫🇷SDU",
+			"group": 2,
+			"x": -516,
+			"y": 1289,
+			"proj": 3
+		},
+		{
+			"name": "St-Rome-de-Cernon",
+			"ril100": "🇫🇷SDO",
+			"group": 2,
+			"x": -519,
+			"y": 1298,
+			"proj": 3
+		},
+		{
+			"name": "Tournemire—Roquefort",
+			"ril100": "🇫🇷TEO",
+			"group": 2,
+			"x": -512,
+			"y": 1305,
+			"proj": 3
+		},
+		{
+			"name": "Montpaon",
+			"ril100": "🇫🇷MNP",
+			"group": 2,
+			"x": -499,
+			"y": 1322,
+			"proj": 3
+		},
+		{
+			"name": "Ceilhes—Roqueredonde",
+			"ril100": "🇫🇷COQ",
+			"group": 2,
+			"x": -493,
+			"y": 1332,
+			"platformLength": 112,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Les Cabrils",
+			"ril100": "🇫🇷KBI",
+			"group": 2,
+			"x": -489,
+			"y": 1337,
+			"proj": 3
+		},
+		{
+			"name": "Lunas",
+			"ril100": "🇫🇷LKH",
+			"group": 2,
+			"x": -488,
+			"y": 1349,
+			"proj": 3
+		},
+		{
+			"name": "Le Bousquet-d'Orb",
+			"ril100": "🇫🇷LBD",
+			"group": 2,
+			"x": -492,
+			"y": 1352,
+			"proj": 3
+		},
+		{
+			"name": "Bédarieux",
+			"ril100": "🇫🇷BED",
+			"group": 2,
+			"x": -495,
+			"y": 1366,
+			"proj": 3
+		},
+		{
+			"name": "Magalas",
+			"ril100": "🇫🇷MGA",
+			"group": 2,
+			"x": -484,
+			"y": 1390,
+			"proj": 3
+		},
+		{
 			"name": "Busenberg-Schindhard",
 			"ril100": "SBNS",
 			"group": 5,

--- a/Station.json
+++ b/Station.json
@@ -34686,6 +34686,222 @@
 			"proj": 3
 		},
 		{
+			"name": "Montrabé",
+			"ril100": "🇫🇷MTB",
+			"group": 2,
+			"x": -726,
+			"y": 1360,
+			"proj": 3
+		},
+		{
+			"name": "Gragnague",
+			"ril100": "🇫🇷GAG",
+			"group": 5,
+			"x": -719,
+			"y": 1351,
+			"platformLength": 196,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Montastruc-la-Conseillère",
+			"ril100": "🇫🇷MCL",
+			"group": 2,
+			"x": -715,
+			"y": 1348,
+			"platformLength": 80,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Roquesérière - Buzet",
+			"ril100": "🇫🇷O11016655586",
+			"group": 5,
+			"x": -711,
+			"y": 1342,
+			"proj": 3
+		},
+		{
+			"name": "St-Sulpice",
+			"ril100": "🇫🇷SST",
+			"group": 2,
+			"x": -702,
+			"y": 1338,
+			"platformLength": 230,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Rabastens-Coufouleux",
+			"ril100": "🇫🇷O1119769298",
+			"group": 2,
+			"x": -695,
+			"y": 1331,
+			"proj": 3
+		},
+		{
+			"name": "Lisle-sur-Tarn",
+			"ril100": "🇫🇷LSU",
+			"group": 2,
+			"x": -684,
+			"y": 1324,
+			"platformLength": 240,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Gaillac",
+			"ril100": "🇫🇷GAI",
+			"group": 2,
+			"x": -671,
+			"y": 1316,
+			"platformLength": 170,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Tessonnières",
+			"ril100": "🇫🇷TES",
+			"group": 2,
+			"x": -665,
+			"y": 1312,
+			"platformLength": 170,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Cordes-Vindrac",
+			"ril100": "🇫🇷VDC",
+			"group": 2,
+			"x": -669,
+			"y": 1289,
+			"platformLength": 250,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Lexos",
+			"ril100": "🇫🇷LEX",
+			"group": 2,
+			"x": -671,
+			"y": 1276,
+			"platformLength": 225,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Laguépie",
+			"ril100": "🇫🇷LPB",
+			"group": 2,
+			"x": -659,
+			"y": 1275,
+			"proj": 3
+		},
+		{
+			"name": "Najac",
+			"ril100": "🇫🇷NAJ",
+			"group": 2,
+			"x": -658,
+			"y": 1262,
+			"platformLength": 95,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Villefranche-de-Rouergue",
+			"ril100": "🇫🇷VRW",
+			"group": 2,
+			"x": -648,
+			"y": 1241,
+			"platformLength": 224,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Salles-Courbatiès",
+			"ril100": "🇫🇷SIR",
+			"group": 2,
+			"x": -641,
+			"y": 1219,
+			"proj": 3
+		},
+		{
+			"name": "Capdenac",
+			"ril100": "🇫🇷CDC",
+			"group": 2,
+			"x": -641,
+			"y": 1202,
+			"platformLength": 301,
+			"platforms": 10,
+			"proj": 3
+		},
+		{
+			"name": "Figeac",
+			"ril100": "🇫🇷FIG",
+			"group": 2,
+			"x": -646,
+			"y": 1198,
+			"platformLength": 122,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Assier",
+			"ril100": "🇫🇷AER",
+			"group": 2,
+			"x": -670,
+			"y": 1186,
+			"proj": 3
+		},
+		{
+			"name": "Gramat",
+			"ril100": "🇫🇷GRT",
+			"group": 2,
+			"x": -690,
+			"y": 1169,
+			"platformLength": 249,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Rocamadour—Padirac",
+			"ril100": "🇫🇷RAP",
+			"group": 2,
+			"x": -698,
+			"y": 1161,
+			"platformLength": 130,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "St-Denis-près-Martel",
+			"ril100": "🇫🇷SDM",
+			"group": 2,
+			"x": -696,
+			"y": 1140,
+			"platformLength": 320,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Les Quatre-Routes",
+			"ril100": "🇫🇷O3423253720",
+			"group": 5,
+			"x": -699,
+			"y": 1131,
+			"proj": 3
+		},
+		{
+			"name": "Turenne",
+			"ril100": "🇫🇷TUR",
+			"group": 2,
+			"x": -705,
+			"y": 1124,
+			"platformLength": 208,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
 			"name": "Kristianstad",
 			"ril100": "🇸🇪7400200",
 			"group": 2,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8913,7 +8913,7 @@
 					"stations": [ "XFBJ", "🇫🇷AGN" ]
 				},
 				{
-					"stations": [ "XFBJ", "🇫🇷LIB", "XFCOU", "🇫🇷LIM" ]
+					"stations": [ "XFBJ", "🇫🇷LIB", "XFCOU", "XFPGX", "🇫🇷LIM" ]
 				},
 				{
 					"stations": [ "🇫🇷ARC", "🇫🇷FAT", "XFBJ", "🇫🇷LIB", "XFCOU" ]


### PR DESCRIPTION
Hinzugefügt Strecken für #1026  
- Brive - Toulouse via Capdenac
- Béziers - Neussargues
- Figeac - Arvant - Clermont-Ferrand
- Perigueux - Ussel

Außerdem minimales Refactoring (Namen hinzugefügt und etwas entflochten) von Bordeaux - Irun, Bordeaux - Sete und Narbonne - Perpignan