### PR TITLE
Bahnsteiglängen Schweden

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -10250,6 +10250,8 @@
 			"group": 2,
 			"x": 1114,
 			"y": -958,
+			"platformLength": 100,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -45705,6 +45707,8 @@
 			"group": 2,
 			"x": 976,
 			"y": -598,
+			"platformLength": 260,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -45777,6 +45781,8 @@
 			"group": 2,
 			"x": 889,
 			"y": -589,
+			"platformLength": 210,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -84755,6 +84761,8 @@
 			"group": 2,
 			"x": 731,
 			"y": -1844,
+			"platformLength": 420,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -84763,6 +84771,8 @@
 			"group": 2,
 			"x": 785,
 			"y": -1845,
+			"platformLength": 260,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -84771,6 +84781,8 @@
 			"group": 2,
 			"x": 830,
 			"y": -1855,
+			"platformLength": 360,
+			"platforms": 4,
 			"proj": 3
 		},
 		{
@@ -93881,14 +93893,18 @@
 			"group": 2,
 			"x": 995,
 			"y": -1221,
+			"platformLength": 210,
+			"platforms": 6,
 			"proj": 3
 		},
 		{
 			"name": "Karlstad central",
 			"ril100": "🇸🇪7400070",
-			"group": 2,
+			"group": 1,
 			"x": 918,
 			"y": -1231,
+			"platformLength": 400,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -93923,6 +93939,8 @@
 			"group": 2,
 			"x": 803,
 			"y": -1274,
+			"platformLength": 240,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -93939,6 +93957,8 @@
 			"group": 2,
 			"x": 765,
 			"y": -1310,
+			"platformLength": 220,
+			"platforms": 2,
 			"proj": 3
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -44191,6 +44191,8 @@
 			"group": 1,
 			"x": 1180,
 			"y": -1423,
+			"platformLength": 250,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -44215,6 +44217,8 @@
 			"group": 1,
 			"x": 1154,
 			"y": -1404,
+			"platformLength": 350,
+			"platforms": 4,
 			"proj": 3
 		},
 		{
@@ -54802,6 +54806,8 @@
 			"group": 1,
 			"x": 1009,
 			"y": -977,
+			"platformLength": 450,
+			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -67480,6 +67486,8 @@
 			"group": 1,
 			"x": 1327,
 			"y": -973,
+			"platformLength": 100,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -93889,6 +93897,8 @@
 			"group": 1,
 			"x": 894,
 			"y": -1251,
+			"platformLength": 200,
+			"platforms": 6,
 			"proj": 3
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -10828,6 +10828,8 @@
 			"group": 5,
 			"x": 841,
 			"y": -689,
+			"platformLength": 170,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -10846,6 +10848,8 @@
 			"group": 5,
 			"x": 861,
 			"y": -679,
+			"platformLength": 170,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -10854,6 +10858,7 @@
 			"group": 5,
 			"x": 866,
 			"y": -672,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -10862,6 +10867,7 @@
 			"group": 2,
 			"x": 878,
 			"y": -670,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -10870,6 +10876,8 @@
 			"group": 5,
 			"x": 888,
 			"y": -669,
+			"platformLength": 170,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -10878,6 +10886,7 @@
 			"group": 5,
 			"x": 881,
 			"y": -677,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -10886,6 +10895,7 @@
 			"group": 5,
 			"x": 877,
 			"y": -690,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -10894,6 +10904,7 @@
 			"group": 5,
 			"x": 863,
 			"y": -700,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -10902,6 +10913,7 @@
 			"group": 5,
 			"x": 889,
 			"y": -647,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20172,6 +20184,7 @@
 			"group": 2,
 			"x": 1473,
 			"y": -1231,
+			"platformLength": 240,
 			"proj": 3
 		},
 		{
@@ -20180,6 +20193,7 @@
 			"group": 2,
 			"x": 1469,
 			"y": -1235,
+			"platformLength": 300,
 			"proj": 3
 		},
 		{
@@ -20188,6 +20202,7 @@
 			"group": 2,
 			"x": 1464,
 			"y": -1238,
+			"platformLength": 340,
 			"proj": 3
 		},
 		{
@@ -20196,6 +20211,7 @@
 			"group": 2,
 			"x": 1454,
 			"y": -1246,
+			"platformLength": 240,
 			"proj": 3
 		},
 		{
@@ -20204,6 +20220,7 @@
 			"group": 2,
 			"x": 1438,
 			"y": -1252,
+			"platformLength": 240,
 			"proj": 3
 		},
 		{
@@ -20212,6 +20229,7 @@
 			"group": 2,
 			"x": 1425,
 			"y": -1261,
+			"platformLength": 300,
 			"proj": 3
 		},
 		{
@@ -20220,6 +20238,7 @@
 			"group": 2,
 			"x": 1369,
 			"y": -1273,
+			"platformLength": 320,
 			"proj": 3
 		},
 		{
@@ -20228,6 +20247,8 @@
 			"group": 1,
 			"x": 1301,
 			"y": -1267,
+			"platformLength": 370,
+			"platforms": 4,
 			"proj": 3
 		},
 		{
@@ -20236,6 +20257,7 @@
 			"group": 2,
 			"x": 1262,
 			"y": -1260,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -20244,6 +20266,7 @@
 			"group": 2,
 			"x": 1234,
 			"y": -1251,
+			"platformLength": 320,
 			"proj": 3
 		},
 		{
@@ -20252,6 +20275,8 @@
 			"group": 2,
 			"x": 1213,
 			"y": -1234,
+			"platformLength": 370,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -20260,6 +20285,8 @@
 			"group": 1,
 			"x": 1135,
 			"y": -1215,
+			"platformLength": 440,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -20268,6 +20295,7 @@
 			"group": 2,
 			"x": 1416,
 			"y": -1199,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20276,6 +20304,7 @@
 			"group": 5,
 			"x": 1382,
 			"y": -1210,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20284,6 +20313,7 @@
 			"group": 2,
 			"x": 1363,
 			"y": -1229,
+			"platformLength": 320,
 			"proj": 3
 		},
 		{
@@ -20292,6 +20322,8 @@
 			"group": 2,
 			"x": 1297,
 			"y": -1229,
+			"platformLength": 340,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -20300,6 +20332,7 @@
 			"group": 2,
 			"x": 1246,
 			"y": -1238,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20316,6 +20349,7 @@
 			"group": 5,
 			"x": 1299,
 			"y": -1196,
+			"platformLength": 120,
 			"proj": 3
 		},
 		{
@@ -20324,6 +20358,7 @@
 			"group": 2,
 			"x": 1273,
 			"y": -1242,
+			"platformLength": 120,
 			"proj": 3
 		},
 		{
@@ -20340,6 +20375,7 @@
 			"group": 5,
 			"x": 1311,
 			"y": -1299,
+			"platformLength": 120,
 			"proj": 3
 		},
 		{
@@ -20348,6 +20384,7 @@
 			"group": 5,
 			"x": 1350,
 			"y": -1318,
+			"platformLength": 137,
 			"proj": 3
 		},
 		{
@@ -20356,6 +20393,7 @@
 			"group": 5,
 			"x": 1337,
 			"y": -1319,
+			"platformLength": 135,
 			"proj": 3
 		},
 		{
@@ -20364,6 +20402,7 @@
 			"group": 2,
 			"x": 1306,
 			"y": -1317,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20372,6 +20411,7 @@
 			"group": 2,
 			"x": 1255,
 			"y": -1349,
+			"platformLength": 350,
 			"proj": 3
 		},
 		{
@@ -20380,6 +20420,7 @@
 			"group": 2,
 			"x": 1249,
 			"y": -1352,
+			"platformLength": 160,
 			"proj": 3
 		},
 		{
@@ -20388,6 +20429,7 @@
 			"group": 2,
 			"x": 1225,
 			"y": -1372,
+			"platformLength": 140,
 			"proj": 3
 		},
 		{
@@ -20396,6 +20438,7 @@
 			"group": 2,
 			"x": 1196,
 			"y": -1383,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -20404,6 +20447,7 @@
 			"group": 2,
 			"x": 1118,
 			"y": -1417,
+			"platformLength": 170,
 			"proj": 3
 		},
 		{
@@ -20412,6 +20456,7 @@
 			"group": 2,
 			"x": 1110,
 			"y": -1423,
+			"platformLength": 130,
 			"proj": 3
 		},
 		{
@@ -20420,6 +20465,7 @@
 			"group": 2,
 			"x": 1112,
 			"y": -1435,
+			"platformLength": 175,
 			"proj": 3
 		},
 		{
@@ -20428,6 +20474,8 @@
 			"group": 2,
 			"x": 1100,
 			"y": -1444,
+			"platformLength": 180,
+			"platforms": 3,
 			"proj": 3
 		},
 		{
@@ -20436,6 +20484,7 @@
 			"group": 2,
 			"x": 1101,
 			"y": -1457,
+			"platformLength": 160,
 			"proj": 3
 		},
 		{
@@ -20444,6 +20493,7 @@
 			"group": 2,
 			"x": 1113,
 			"y": -1468,
+			"platformLength": 140,
 			"proj": 3
 		},
 		{
@@ -21422,6 +21472,7 @@
 			"group": 2,
 			"x": 1312,
 			"y": -1469,
+			"platformLength": 120,
 			"proj": 3
 		},
 		{
@@ -21430,6 +21481,7 @@
 			"group": 2,
 			"x": 1305,
 			"y": -1493,
+			"platformLength": 105,
 			"proj": 3
 		},
 		{
@@ -21438,6 +21490,7 @@
 			"group": 2,
 			"x": 1311,
 			"y": -1504,
+			"platformLength": 111,
 			"proj": 3
 		},
 		{
@@ -21446,6 +21499,7 @@
 			"group": 2,
 			"x": 1291,
 			"y": -1522,
+			"platformLength": 130,
 			"proj": 3
 		},
 		{
@@ -21454,6 +21508,7 @@
 			"group": 2,
 			"x": 1268,
 			"y": -1540,
+			"platformLength": 406,
 			"proj": 3
 		},
 		{
@@ -21462,6 +21517,8 @@
 			"group": 2,
 			"x": 1266,
 			"y": -1559,
+			"platformLength": 111,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -21470,6 +21527,8 @@
 			"group": 2,
 			"x": 1264,
 			"y": -1566,
+			"platformLength": 105,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -21478,6 +21537,8 @@
 			"group": 2,
 			"x": 1238,
 			"y": -1597,
+			"platformLength": 120,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -21486,6 +21547,7 @@
 			"group": 2,
 			"x": 1228,
 			"y": -1614,
+			"platformLength": 260,
 			"proj": 3
 		},
 		{
@@ -39342,6 +39404,7 @@
 			"group": 2,
 			"x": 869,
 			"y": -1227,
+			"platformLength": 160,
 			"proj": 3
 		},
 		{
@@ -39350,6 +39413,8 @@
 			"group": 2,
 			"x": 845,
 			"y": -1192,
+			"platformLength": 100,
+			"platforms": 1,
 			"proj": 3
 		},
 		{
@@ -39358,6 +39423,7 @@
 			"group": 2,
 			"x": 818,
 			"y": -1178,
+			"platformLength": 180,
 			"proj": 3
 		},
 		{
@@ -39374,6 +39440,7 @@
 			"group": 2,
 			"x": 789,
 			"y": -1123,
+			"platformLength": 380,
 			"proj": 3
 		},
 		{
@@ -57810,6 +57877,7 @@
 			"group": 2,
 			"x": 1488,
 			"y": -1215,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -57818,6 +57886,7 @@
 			"group": 2,
 			"x": 1500,
 			"y": -1208,
+			"platformLength": 270,
 			"proj": 3
 		},
 		{
@@ -57826,6 +57895,7 @@
 			"group": 5,
 			"x": 1504,
 			"y": -1207,
+			"platformLength": 240,
 			"proj": 3
 		},
 		{
@@ -57834,6 +57904,7 @@
 			"group": 2,
 			"x": 1507,
 			"y": -1205,
+			"platformLength": 270,
 			"proj": 3
 		},
 		{
@@ -57842,6 +57913,7 @@
 			"group": 2,
 			"x": 1505,
 			"y": -1200,
+			"platformLength": 240,
 			"proj": 3
 		},
 		{
@@ -57850,6 +57922,7 @@
 			"group": 5,
 			"x": 1505,
 			"y": -1197,
+			"platformLength": 310,
 			"proj": 3
 		},
 		{
@@ -57858,6 +57931,7 @@
 			"group": 2,
 			"x": 1504,
 			"y": -1193,
+			"platformLength": 260,
 			"proj": 3
 		},
 		{
@@ -57866,6 +57940,7 @@
 			"group": 5,
 			"x": 1501,
 			"y": -1190,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -57874,6 +57949,7 @@
 			"group": 2,
 			"x": 1497,
 			"y": -1188,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -57882,6 +57958,7 @@
 			"group": 5,
 			"x": 1494,
 			"y": -1187,
+			"platformLength": 280,
 			"proj": 3
 		},
 		{
@@ -57890,6 +57967,7 @@
 			"group": 2,
 			"x": 1486,
 			"y": -1182,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -57898,6 +57976,7 @@
 			"group": 2,
 			"x": 1480,
 			"y": -1175,
+			"platformLength": 250,
 			"proj": 3
 		},
 		{
@@ -57906,6 +57985,7 @@
 			"group": 2,
 			"x": 1477,
 			"y": -1168,
+			"platformLength": 280,
 			"proj": 3
 		},
 		{
@@ -57914,6 +57994,7 @@
 			"group": 5,
 			"x": 1483,
 			"y": -1157,
+			"platformLength": 280,
 			"proj": 3
 		},
 		{
@@ -57922,6 +58003,8 @@
 			"group": 2,
 			"x": 1484,
 			"y": -1155,
+			"platformLength": 240,
+			"platforms": 4,
 			"proj": 3
 		},
 		{


### PR DESCRIPTION
Um längere Züge in Schweden zu erlauben, an einigen Stationen Bahnsteigdaten ergänzt.