### PR TITLE
Update Station

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -48561,7 +48561,7 @@
 			"ril100": "RB",
 			"x": 141,
 			"y": 698,
-			"platformLength": 350,
+			"platformLength": 600,
 			"platforms": 10,
 			"proj": 3
 		},


### PR DESCRIPTION
Bahnsteig Basel Bad verlängert, Messung durch Google Maps, falls jemand abweichende Daten findet, gerne ändern