### PR TITLE
Überarbeitung Gäubahn + Stuttgart - Filderstadt

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -63143,10 +63143,36 @@
 			"objects": [
 				{
 					"start": "RIM",
+					"end": "RIMM",
+					"length": 1,
+					"maxSpeed": 60,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "RIMM",
+					"end": "TMHR",
+					"length": 5,
+					"maxSpeed": 110,
+					"twistingFactor": 0.48
+				},
+				{
+					"start": "TMHR",
+					"end": "TMHB",
+					"length": 1,
+					"maxSpeed": 110,
+					"twistingFactor": 0.0
+				},
+				{
+					"start": "TMHB",
+					"end": "TTUG",
+					"length": 1,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "TTUG",
 					"end": "TTU",
-					"length": 10,
-					"twistingFactor": 0.24,
-					"electrified": true
+					"length": 2,
+					"twistingFactor": 0.0
 				},
 				{
 					"start": "TTU",
@@ -65335,27 +65361,90 @@
 			"electrified": true,
 			"name": "Gäubahn",
 			"group": 0,
+			"twistingFactor": 0.0,
+			"maxSpeed": 140,
 			"objects": [
-				{
+			    {
 					"start": "TS",
+					"end": "TSV",
+					"length": 12,
+					"maxSpeed": 90,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "TSV",
+					"end": "TSRO",
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.35
+				},
+				{
+					"start": "TSRO",
+					"end": "TGOL",
+					"length": 8,
+					"maxSpeed": 130,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "TGOL",
 					"end": "TBO",
-					"length": 25,
 					"maxSpeed": 120,
-					"twistingFactor": 0.3
+					"length": 1
 				},
 				{
 					"start": "TBO",
+					"end": "THUB",
+					"length": 2
+				},
+				{
+					"start": "THUB",
+					"end": "TEHN",
+					"length": 3
+				},
+				{
+					"start": "TEHN",
+					"end": "TGT",
+					"length": 4,
+					"maxSpeed": 130,
+					"twistingFactor": 0.36
+				},
+				{
+					"start": "TGT",
+					"end": "TNUF",
+					"length": 3,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "TNUF",
 					"end": "THE",
-					"length": 15,
-					"maxSpeed": 140,
-					"twistingFactor": 0.2
+					"length": 4,
+					"maxSpeed": 120,
+					"twistingFactor": 0.42
 				},
 				{
 					"start": "THE",
+					"end": "TGFD",
+					"length": 5,
+					"twistingFactor": 0.27
+				},
+				{
+					"start": "TGFD",
+					"end": "TBD",
+					"length": 4,
+					"twistingFactor": 0.08
+				},
+				{
+					"start": "TBD",
+					"end": "TEG",
+					"length": 4,
+					"twistingFactor": 0.11
+				},
+				{
+					"start": "TEG",
 					"end": "TET",
-					"length": 15,
-					"maxSpeed": 140,
-					"twistingFactor": 0.2
+					"length": 2,
+					"maxSpeed": 130,
+					"twistingFactor": 0.18
 				},
 				{
 					"start": "TET",
@@ -65387,17 +65476,94 @@
 				},
 				{
 					"start": "TR",
-					"end": "TSP",
-					"length": 14,
+					"end": "TRG",
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.41
+				},
+				{
+					"start": "TRG",
+					"end": "TRSA",
+					"length": 1,
+					"maxSpeed": 100,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "TRSA",
+					"end": "TRNF",
+					"length": 3,
+					"maxSpeed": 140,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "TRNF",
+					"end": "TALD",
+					"length": 5,
 					"maxSpeed": 120,
-					"twistingFactor": 0.27
+					"twistingFactor": 0.34
+				},
+				{
+					"start": "TALD",
+					"end": "TSPM",
+					"length": 3,
+					"maxSpeed": 120,
+					"twistingFactor": 0.41
+				},
+				{
+					"start": "TSPM",
+					"end": "TSP",
+					"length": 2,
+					"maxSpeed": 120,
+					"twistingFactor": 0.18
 				},
 				{
 					"start": "TSP",
+					"end": "TBLH",
+					"maxSpeed": 120,
+					"length": 1
+				},
+				{
+					"start": "TBLH",
+					"end": "TRH",
+					"length": 4,
+					"maxSpeed": 130,
+					"twistingFactor": 0.23
+				},
+				{
+					"start": "TRH",
+					"end": "TWLH",
+					"length": 2,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "TWLH",
+					"end": "TWUN",
+					"length": 2
+				},
+				{
+					"start": "TWUN",
+					"end": "TWUM",
+					"length": 1
+				},
+				{
+					"start": "TWUM",
+					"end": "TTUS",
+					"length": 2,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "TTUS",
 					"end": "TTU",
-					"length": 12,
-					"maxSpeed": 140,
-					"twistingFactor": 0.24
+					"length": 1,
+					"maxSpeed": 80,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "TTU",
+					"end": "RENG",
+					"length": 19,
+					"maxSpeed": 90,
+					"twistingFactor": 0.49
 				}
 			]
 		},
@@ -85629,6 +85795,47 @@
 					"length": 6,
 					"maxSpeed": 75,
 					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"name": "Stuttgart - Filderstadt",
+			"group": 0,
+			"twistingFactor": 0.0,
+			"maxSpeed": 100,
+			"objects": [
+			    {
+					"start": "TSRO",
+					"end": "TOAI",
+					"length": 2,
+					"twistingFactor": 0.31
+				},
+				{
+					"start": "TOAI",
+					"end": "TLF",
+					"length": 2,
+					"maxSpeed": 80,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "TLF",
+					"end": "TETD",
+					"length": 2,
+					"maxSpeed": 90,
+				},
+				{
+					"start": "TETD",
+					"end": "TFL",
+					"length": 2,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "TFL",
+					"end": "TFIL",
+					"length": 3,
+					"maxSpeed": 80,
+					"twistingFactor": 0.43
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -95716,6 +95716,284 @@
 			"platformLength": 239,
 			"platforms": 2,
 			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Stuttgart-Vaihingen",
+			"ril100": "TSV",
+			"x": 344,
+			"y": 498,
+			"platformLength": 249,
+			"platforms": 5,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Stuttgart-Rohr",
+			"ril100": "TSRO",
+			"x": 343,
+			"y": 503,
+			"platformLength": 218,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Goldberg (Württ)",
+			"ril100": "TGOL",
+			"x": 338,
+			"y": 508,
+			"platformLength": 213,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Hulb",
+			"ril100": "THUB",
+			"x": 334,
+			"y": 511,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ehningen (b Böblingen)",
+			"ril100": "TEHN",
+			"x": 329,
+			"y": 515,
+			"platformLength": 236,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Gärtringen",
+			"ril100": "TGT",
+			"x": 325,
+			"y": 519,
+			"platformLength": 210,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Nufringen",
+			"ril100": "TNUF",
+			"x": 321,
+			"y": 522,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gäufelden",
+			"ril100": "TGFD",
+			"x": 316,
+			"y": 531,
+			"platformLength": 234,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Bondorf (b Herrenberg)",
+			"ril100": "TBD",
+			"x": 313,
+			"y": 536,
+			"platformLength": 210,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ergenzingen",
+			"ril100": "TEG",
+			"x": 309,
+			"y": 540,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Rottweil Göllsdorf",
+			"ril100": "TRG",
+			"x": 288,
+			"y": 599,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Rottweil Saline",
+			"ril100": "TRSA",
+			"x": 289,
+			"y": 602,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Rottweil Neufra",
+			"ril100": "TRNF",
+			"x": 293,
+			"y": 606,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Aldingen (b Spaichingen)",
+			"ril100": "TALD",
+			"x": 297,
+			"y": 610,
+			"platformLength": 180,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Spaichingen Mitte",
+			"ril100": "TSPM",
+			"x": 299,
+			"y": 612,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Balgheim",
+			"ril100": "TBLH",
+			"x": 302,
+			"y": 615,
+			"platformLength": 81,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Rietheim (Württ)",
+			"ril100": "TRH",
+			"x": 305,
+			"y": 618,
+			"platformLength": 80,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Weilheim (Württ)",
+			"ril100": "TWLH",
+			"x": 305,
+			"y": 621,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Wurmlingen Nord",
+			"ril100": "TWUN",
+			"x": 305,
+			"y": 624,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Wurmlingen Mitte",
+			"ril100": "TWUM",
+			"x": 306,
+			"y": 625,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Tuttlingen Schulen",
+			"ril100": "TTUS",
+			"x": 309,
+			"y": 627,
+			"platformLength": 80,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Tuttlingen Gansäcker",
+			"ril100": "TTUG",
+			"x": 306,
+			"y": 631,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Möhringen Bahnhof",
+			"ril100": "TMHB",
+			"x": 304,
+			"y": 632,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Möhringen Rathaus",
+			"ril100": "TMHR",
+			"x": 303,
+			"y": 632,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Immendingen Mitte",
+			"ril100": "RIMM",
+			"x": 299,
+			"y": 635,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Oberaichen",
+			"ril100": "TOAI",
+			"x": 348,
+			"y": 506,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Leinfelden",
+			"ril100": "TLF",
+			"x": 351,
+			"y": 509,
+			"platformLength": 212,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Echterdingen",
+			"ril100": "TETD",
+			"x": 355,
+			"y": 510,
+			"platformLength": 212,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Stuttgart Flughafen/Messe",
+			"ril100": "TFL",
+			"x": 359,
+			"y": 510,
+			"platformLength": 251,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Filderstadt",
+			"ril100": "TFIL",
+			"x": 361,
+			"y": 512,
+			"platformLength": 210,
+			"platforms": 2,
+			"proj": 3
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -12059,7 +12059,7 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Fahre im Auftrag der S-Bahn Stuttgart auf der Linie S3 von %s nach %s."
 			],
-			"stations": [ "TS", "TFE", "TWN", "TNHO", "TSWK", "TWI", "TNL", "TMAU", "TB" ],
+			"stations": [ "TFL", "TSRO", "TSV", "TS", "TFE", "TWN", "TNHO", "TSWK", "TWI", "TNL", "TMAU", "TB" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -12074,7 +12074,7 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Fahre im Auftrag der S-Bahn Stuttgart auf der Linie S2 von %s nach %s."
 			],
-			"stations": [ "TS", "TFE", "TWN", "TROM", "TSTE", "TEN", "TBTB", "TGC", "TGES", "TWIN", "TWEL", "TSF" ],
+			"stations": [ "TFIL", "TFL", "TSRO", "TSV", "TS", "TFE", "TWN", "TROM", "TSTE", "TEN", "TBTB", "TGC", "TGES", "TWIN", "TWEL", "TSF" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
@@ -12944,6 +12944,104 @@
 					"stations": [ "SDL", "SHEM", "XFBZV" ]
 				}
 			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RB43 von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den Ringzug von %s nach %s",
+				"Bring deine Fahrgäste pünktlich auf der RB43 nach %2$s!",
+				"Fahre die Linie RB43 von %s bis %s. Halte dabei an jeder Milchkanne."
+			],
+			"stations": [ "TR", "TRSA", "TSP", "TTU", "TMHB", "RIM" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RE4 von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den Freizeitexpress Bodensee von %s nach %s",
+				"Bring deine Fahrgäste nach %2$s. Achte darauf, dass diese Verbindung insbesondere im Sommer bei Radlern sehr beliebt ist!",
+			],
+			"objects": [
+				{
+					"stations": [ "TS", "TSV", "TBO", "THE", "TGFD", "TBD", "THB", "TSUL", "TOB", "TR", "TSP", "TTU", "RENG", "RSI", "RRZ", "RAB", "RKO" ],
+					"pathSuggestion": [ "TS", "TSV", "TSRO", "TBO", "THE", "TGFD", "TBD", "TET", "THB", "TSUL", "TOB", "TR", "TRSA", "TSP", "TTU", "RENG", "RSI", "RRZ", "RAB", "RKO" ]
+				},
+				{
+					"stations": [ "TR", "TTU", "RENG", "RSI" ],
+					"pathSuggestion": [ "TR", "TRSA", "TTU", "RENG", "RSI" ],
+					"descriptions": [
+						"Fahre einen Verstärkerzug auf der südlichen Gäubahn"
+					]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RE14a von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den Regionalexpress von %s nach %s",
+				"Bring deine Fahrgäste pünktlich auf dem RE14a nach %2$s!",
+				"Fahre die Linie RE14a von %s nach %s."
+			],
+			"stations": [ "TS", "TBO", "THE", "TGFD", "TBD", "TEG", "TET", "THB", "TSUL", "TOB", "TR" ],
+			"pathSuggestion": [ "TS", "TSV", "TSRO", "TBO", "THE", "TGFD", "TBD", "TEG", "TET", "THB", "TSUL", "TOB", "TR" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RE14a/RB43 von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den Schülerzug RE14a/RB43 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich nach %2$s!"
+			],
+			"stations": [ "TS", "TSV", "TBO", "TGT", "THE", "TGFD", "TBD", "TEG", "TET", "THB", "TSUL", "TOB", "TR", "TRG", "TRSA", "TRNF", "TALD", "TSPM", "TSP", "TBLH", "TRH", "TWLH", "TWUM", "TTUS", "TTU" ],
+			"pathSuggestion": [ "TS", "TSV", "TSRO", "TBO", "TGT", "THE", "TGFD", "TBD", "TEG", "TET", "THB", "TSUL", "TOB", "TR", "TRG", "TRSA", "TRNF", "TALD", "TSPM", "TSP", "TBLH", "TRH", "TWLH", "TWUM", "TTUS", "TTU" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "RB14a von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre die Regionalbahn 14a von %s nach %s",
+				"Bring deine Fahrgäste pünktlich auf der Linie RB14a nach %2$s!",
+				"Fahre die Linie RB14a von %s nach %s."
+			],
+			"stations": [ "THE", "TGFD", "TBD", "TEG", "TET" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "S1 von %s nach %s",
+			"service": 3,
+			"descriptions": [
+				"Fahre die Linie S1 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich auf der S1 nach %2$s!",
+				"Fahre im Auftrag der S-Bahn Stuttgart auf der Linie S1 von %s nach %s."
+			],
+			"stations": [ "THE", "TBO", "TSRO", "TSV", "TS", "TP", "TWD" ],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]


### PR DESCRIPTION
Folgende Sachen aus #977 werden hinzugefügt:
- Überarbeitung gesamte Gäubahn
- Stuttgart-Vaihingen - Filderstadt
- diverse neue Tasks für Züge auf der Gäubahn und Erweiterung S-Bahn zum Flughafen