### PR TITLE
Überarbeitung Filstalbahn + Lokalbahn Amstetten - Gerstetten

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -86971,7 +86971,7 @@
 		{
 			"electrified": false,
 			"name": "Lokalbahn Amstetten - Gerstetten",
-			"group": 0,
+			"group": 1,
 			"twistingFactor": 0.3,
 			"maxSpeed": 50,
 			"objects": [

--- a/Path.json
+++ b/Path.json
@@ -63348,48 +63348,6 @@
 					"length": 24,
 					"maxSpeed": 160,
 					"twistingFactor": 0.2
-				},
-				{
-					"start": "TU",
-					"end": "TLON",
-					"length": 21,
-					"maxSpeed": 120,
-					"twistingFactor": 0.34
-				},
-				{
-					"start": "TLON",
-					"end": "TG",
-					"length": 11,
-					"maxSpeed": 110,
-					"twistingFactor": 0.34
-				},
-				{
-					"start": "TG",
-					"end": "TGO",
-					"length": 19,
-					"maxSpeed": 160,
-					"twistingFactor": 0.2
-				},
-				{
-					"start": "TGO",
-					"end": "TP",
-					"length": 19,
-					"maxSpeed": 160,
-					"twistingFactor": 0.2
-				},
-				{
-					"start": "TP",
-					"end": "TE",
-					"length": 9,
-					"maxSpeed": 150,
-					"twistingFactor": 0.2
-				},
-				{
-					"start": "TE",
-					"end": "TS",
-					"length": 12,
-					"maxSpeed": 130,
-					"twistingFactor": 0.2
 				}
 			]
 		},
@@ -86823,6 +86781,227 @@
 					"length": 21,
 					"maxSpeed": 250,
 					"twistingFactor": 0.1
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"name": "Filstalbahn",
+			"group": 0,
+			"twistingFactor": 0.0,
+			"maxSpeed": 160,
+			"objects": [
+			    {
+					"start": "TS",
+					"end": "TSNS",
+					"length": 5,
+					"maxSpeed": 110,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "TSNS",
+					"end": "TSU",
+					"length": 2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TSU",
+					"end": "TSOM",
+					"length": 2,
+					"maxSpeed": 100
+				},
+				{
+					"start": "TSOM",
+					"end": "TEME",
+					"length": 2,
+					"maxSpeed": 130
+				},
+				{
+					"start": "TEME",
+					"end": "TE",
+					"length": 2,
+					"maxSpeed": 150,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "TE",
+					"end": "TOES",
+					"length": 2,
+					"maxSpeed": 150
+				},
+				{
+					"start": "TOES",
+					"end": "TEZL",
+					"length": 3,
+					"maxSpeed": 150,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "TEZL",
+					"end": "TACH",
+					"length": 2,
+					"maxSpeed": 150,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "TACH",
+					"end": "TP",
+					"length": 2,
+					"maxSpeed": 130,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "TP",
+					"end": "TRF",
+					"length": 5,
+					"maxSpeed": 110,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "TRF",
+					"end": "TEC",
+					"length": 5,
+					"maxSpeed": 150,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "TEC",
+					"end": "TUH",
+					"length": 5,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "TUH",
+					"end": "TFAU",
+					"length": 2,
+					"maxSpeed": 150,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "TFAU",
+					"end": "TGO",
+					"length": 3,
+					"maxSpeed": 140,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "TGO",
+					"end": "TEF",
+					"length": 4,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "TEF",
+					"end": "TSAL",
+					"length": 2
+				},
+				{
+					"start": "TSAL",
+					"end": "TSD",
+					"length": 2
+				},
+				{
+					"start": "TSD",
+					"end": "TGI",
+					"length": 3
+				},
+				{
+					"start": "TGI",
+					"end": "TKUC",
+					"length": 3
+				},
+				{
+					"start": "TKUC",
+					"end": "TGW",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "TGW",
+					"end": "TG",
+					"length": 3,
+					"maxSpeed": 70,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "TG",
+					"end": "TAM",
+					"length": 6,
+					"maxSpeed": 70,
+					"twistingFactor": 0.5
+				},
+				{
+					"start": "TAM",
+					"end": "TURS",
+					"length": 4,
+					"maxSpeed": 110,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "TURS",
+					"end": "TLON",
+					"length": 2,
+					"maxSpeed": 110,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "TLON",
+					"end": "TWSH",
+					"length": 4,
+					"maxSpeed": 110,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "TWSH",
+					"end": "TBS",
+					"length": 5,
+					"maxSpeed": 110,
+					"twistingFactor": 0.45
+				},
+				{
+					"start": "TBS",
+					"end": "TU",
+					"length": 12,
+					"maxSpeed": 140,
+					"twistingFactor": 0.3
+				}
+			]
+		},
+		{
+			"electrified": false,
+			"name": "Lokalbahn Amstetten - Gerstetten",
+			"group": 0,
+			"twistingFactor": 0.3,
+			"maxSpeed": 50,
+			"objects": [
+			    {
+					"start": "TAM",
+					"end": "TSBH",
+					"length": 5,
+					"maxSpeed": 20,
+					"twistingFactor": 0.6
+				},
+				{
+					"start": "TSBH",
+					"end": "TSKS",
+					"length": 5
+				},
+				{
+					"start": "TSKS",
+					"end": "TWHS",
+					"length": 5,
+					"twistingFactor": 0.1
+				},
+				{
+					"start": "TWHS",
+					"end": "TGSS",
+					"length": 5
+				},
+				{
+					"start": "TGSS",
+					"end": "TGSN",
+					"length": 5
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -97307,6 +97307,246 @@
 			"platformLength": 372,
 			"platforms": 4,
 			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Stuttgart Neckarpark",
+			"ril100": "TSNS",
+			"x": 359,
+			"y": 491,
+			"platformLength": 210,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Stuttgart-Untertürkheim",
+			"ril100": "TSU",
+			"x": 364,
+			"y": 493,
+			"platformLength": 211,
+			"platforms": 5,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Stuttgart-Obertürkheim",
+			"ril100": "TSOM",
+			"x": 368,
+			"y": 495,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Esslingen-Mettingen",
+			"ril100": "TEME",
+			"x": 373,
+			"y": 497,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Oberesslingen",
+			"ril100": "TOES",
+			"x": 383,
+			"y": 499,
+			"platformLength": 312,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Esslingen-Zell",
+			"ril100": "TEZL",
+			"x": 389,
+			"y": 499,
+			"platformLength": 301,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Altbach",
+			"ril100": "TACH",
+			"x": 395,
+			"y": 500,
+			"platformLength": 297,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Reichenbach (Fils)",
+			"ril100": "TRF",
+			"x": 406,
+			"y": 502,
+			"platformLength": 205,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Ebersbach (Fils)",
+			"ril100": "TEC",
+			"x": 412,
+			"y": 503,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Uhingen",
+			"ril100": "TUH",
+			"x": 418,
+			"y": 505,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Faurndau",
+			"ril100": "TFAU",
+			"x": 420,
+			"y": 506,
+			"platformLength": 195,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Eislingen (Fils)",
+			"ril100": "TEF",
+			"x": 430,
+			"y": 509,
+			"platformLength": 243,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Salach",
+			"ril100": "TSAL",
+			"x": 434,
+			"y": 510,
+			"platformLength": 210,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Süßen",
+			"ril100": "TSD",
+			"x": 437,
+			"y": 511,
+			"platformLength": 281,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gingen (Fils)",
+			"ril100": "TGI",
+			"x": 441,
+			"y": 514,
+			"platformLength": 241,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Kuchen",
+			"ril100": "TKUC",
+			"x": 446,
+			"y": 517,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Geislingen (Steige) West",
+			"ril100": "TGW",
+			"x": 449,
+			"y": 519,
+			"platformLength": 236,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Amstetten (Württ)",
+			"ril100": "TAM",
+			"x": 456,
+			"y": 527,
+			"platformLength": 190,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Urspring",
+			"ril100": "TURS",
+			"x": 459,
+			"y": 532,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Westerstetten",
+			"ril100": "TWSH",
+			"x": 465,
+			"y": 539,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Beimerstetten",
+			"ril100": "TBS",
+			"x": 468,
+			"y": 545,
+			"platformLength": 190,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Stubersheim",
+			"ril100": "TSBH",
+			"x": 463,
+			"y": 525,
+			"platformLength": 38,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Schalkstetten",
+			"ril100": "TSKS",
+			"x": 461,
+			"y": 521,
+			"platformLength": 40,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Waldhausen (b Geislingen)",
+			"ril100": "TWHS",
+			"x": 461,
+			"y": 516,
+			"platformLength": 36,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gussenstadt",
+			"ril100": "TGSS",
+			"x": 466,
+			"y": 514,
+			"platformLength": 40,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Gerstetten",
+			"ril100": "TGSN",
+			"x": 471,
+			"y": 515,
+			"platformLength": 65,
+			"platforms": 2,
+			"proj": 3
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -13317,6 +13317,34 @@
 			"neededCapacity": [
 				{ "name": "passengers"}
 			]
+		},
+		{
+			"group": 1,
+			"name": "MEX16 von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie MEX16 von %s nach %s",
+				"Bring deine Fahrgäste pünktlich auf der Metropolexpress-Linie 16 nach %2$s!",
+				"Fahre die Linie MEX16 von %s bis %s. Lasse dich dabei desöfteren durch andere verspätete Züge zur Seite nehmen."
+			],
+			"stations": [ "TS", "TE", "TP", "TRF", "TEC", "TUH", "TFAU", "TGO", "TEF", "TSAL", "TSD", "TGI", "TKUC", "TGW", "TG", "TAM", "TURS", "TLON", "TWSH", "TBS", "TU" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "SAB von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre auf der Linie RB58 von %s nach %s",
+				"Bring Ausflügler pünktlich auf der Lokalbahn Amstetten - Gerstetten nach %2$s!",
+				"Fahre im Auftrag der Schwäbischen Alb-Bahn von %s bis %s. Beachte, dass die Bahnsteige auf der Strecke sehr kurz und niedrig sind!"
+			],
+			"stations": [ "TAM", "TSBH", "TSKS", "TWHS", "TGSS", "TGSN" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
 		}
 	]
 }


### PR DESCRIPTION
Folgende Sachen aus #977 werden hinzugefügt:
- Überarbeitung Strecke Stuttgart - Ulm (mit allen Unterwegshalten)
- neue Strecke Amstetten - Gerstetten
- Task für MEX16 Stuttgart Hbf - Ulm Hbf
- Task für SAB-Ausflugszug Amstetten - Gerstetten