### PR TITLE
Update Hagen Hbf

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -20585,8 +20585,8 @@
 			"ril100": "EHG",
 			"x": 130,
 			"y": 65,
-			"platformLength": 272,
-			"platforms": 16,
+			"platformLength": 542,
+			"platforms": 10,
 			"proj": 3
 		},
 		{


### PR DESCRIPTION
Hagen Hbf hat Bahnsteige mit Mittelweiche wodurch es "2 Bahnsteige" sind, Doppelbahnsteige nun zusammengefasst, dadurch Länge verdoppelt, aber Anzahl an Bahnsteigen verringert, damit die Station nicht "zu groß" wird.