### PR TITLE
Überarbeitung Vendenheim - Wissembourg + dazugehörige Tasks

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -87941,6 +87941,9 @@
 		},
 		{
 			"electrified": false,
+			"neededEquipments": [
+				"FR"
+			],
 			"name": "Ligne 33",
 			"group": 1,
 			"twistingFactor": 0.1,

--- a/Path.json
+++ b/Path.json
@@ -41454,29 +41454,6 @@
 			]
 		},
 		{
-			"electrified": false,
-			"group": 0,
-			"neededEquipments": [
-				"FR"
-			],
-			"objects": [
-				{
-					"start": "XFWBG",
-					"end": "XFHG",
-					"length": 33,
-					"maxSpeed": 100,
-					"twistingFactor": 0.2
-				},
-				{
-					"start": "XFHG",
-					"end": "XFVH",
-					"length": 24,
-					"maxSpeed": 160,
-					"twistingFactor": 0.26
-				}
-			]
-		},
-		{
 			"name": "Mannheim–Stuttgart",
 			"electrified": true,
 			"group": 2,
@@ -87959,6 +87936,97 @@
 					"start": "TWD",
 					"end": "TRHZ",
 					"length": 3
+				}
+			]
+		},
+		{
+			"electrified": false,
+			"name": "Ligne 33",
+			"group": 1,
+			"twistingFactor": 0.1,
+			"maxSpeed": 160,
+			"objects": [
+			    {
+					"start": "XFVH",
+					"end": "OFH",
+					"length": 7,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "OFH",
+					"end": "OFWH",
+					"length": 2
+				},
+				{
+					"start": "OFWH",
+					"end": "OFKHE",
+					"length": 3,
+					"twistingFactor": 0.0
+				},
+				{
+					"start": "OFKHE",
+					"end": "OFBW",
+					"length": 5,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "OFBW",
+					"end": "OFMAT",
+					"length": 3,
+					"twistingFactor": 0.0,
+					"maxSpeed": 120
+				},
+				{
+					"start": "OFMAT",
+					"end": "XFHG",
+					"length": 5,
+					"maxSpeed": 120
+				},
+				{
+					"start": "XFHG",
+					"end": "OFWB",
+					"length": 8,
+					"twistingFactor": 0.0,
+					"maxSpeed": 100
+				},
+				{
+					"start": "OFWB",
+					"end": "OFHLS",
+					"length": 4,
+					"twistingFactor": 0.2,
+					"maxSpeed": 100
+				},
+				{
+					"start": "OFHLS",
+					"end": "OFSZ",
+					"length": 5,
+					"maxSpeed": 100
+				},
+				{
+					"start": "OFSZ",
+					"end": "OFHF",
+					"length": 4,
+					"maxSpeed": 100
+				},
+				{
+					"start": "OFHF",
+					"end": "🇫🇷HUS",
+					"length": 4,
+					"twistingFactor": 0.32,
+					"maxSpeed": 100
+				},
+				{
+					"start": "🇫🇷HUS",
+					"end": "OFRSZ",
+					"length": 3,
+					"maxSpeed": 100
+				},
+				{
+					"start": "OFRSZ",
+					"end": "XFWBG",
+					"length": 5,
+					"twistingFactor": 0.15,
+					"maxSpeed": 100
 				}
 			]
 		}

--- a/Station.json
+++ b/Station.json
@@ -5966,8 +5966,8 @@
 			"name": "Haguenau",
 			"ril100": "XFHG",
 			"group": 2,
-			"x": 169,
-			"y": 489,
+			"x": 167,
+			"y": 488,
 			"platformLength": 230,
 			"platforms": 3,
 			"proj": 3
@@ -56195,8 +56195,8 @@
 			"name": "Vendenheim",
 			"ril100": "XFVH",
 			"group": 1,
-			"x": 146,
-			"y": 503,
+			"x": 151,
+			"y": 506,
 			"platformLength": 234,
 			"platforms": 5,
 			"proj": 3
@@ -58184,9 +58184,9 @@
 			"group": 2,
 			"name": "Wissembourg",
 			"ril100": "XFWBG",
-			"x": 193,
-			"y": 459,
-			"platformLength": 190,
+			"x": 185,
+			"y": 460,
+			"platformLength": 200,
 			"platforms": 3,
 			"proj": 3
 		},
@@ -95716,40 +95716,40 @@
 			"name": "Schweighouse-sur-Moder",
 			"ril100": "OFSGH",
 			"group": 5,
-			"x": 168,
-			"y": 487,
+			"x": 166,
+			"y": 485,
 			"proj": 3
 		},
 		{
 			"name": "Mertzwiller",
 			"ril100": "OFMZS",
 			"group": 5,
-			"x": 155,
-			"y": 480,
+			"x": 153,
+			"y": 479,
 			"proj": 3
 		},
 		{
 			"name": "Gundershoffen",
 			"ril100": "OFGH",
 			"group": 5,
-			"x": 152,
-			"y": 476,
+			"x": 150,
+			"y": 475,
 			"proj": 3
 		},
 		{
 			"name": "Reichshoffen",
 			"ril100": "OFRHV",
 			"group": 5,
-			"x": 153,
-			"y": 472,
+			"x": 151,
+			"y": 471,
 			"proj": 3
 		},
 		{
 			"name": "Niederbronn-les-Bains",
 			"ril100": "OFNBN",
 			"group": 2,
-			"x": 150,
-			"y": 468,
+			"x": 148,
+			"y": 467,
 			"platformLength": 150,
 			"platforms": 1,
 			"proj": 3
@@ -98759,6 +98759,107 @@
 			"x": 299,
 			"y": 550,
 			"platformLength": 107,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Hoerdt",
+			"ril100": "OFH",
+			"x": 159,
+			"y": 504,
+			"platformLength": 180,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Weyersheim",
+			"ril100": "OFWH",
+			"x": 161,
+			"y": 502,
+			"platformLength": 180,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Kurtzenhouse",
+			"ril100": "OFKHE",
+			"x": 164,
+			"y": 499,
+			"platformLength": 180,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Bischwiller",
+			"ril100": "OFBW",
+			"x": 172,
+			"y": 495,
+			"platformLength": 220,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Marienthal",
+			"ril100": "OFMAT",
+			"x": 170,
+			"y": 492,
+			"platformLength": 180,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Walbourg",
+			"ril100": "OFWB",
+			"x": 170,
+			"y": 479,
+			"platformLength": 190,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Hoelschloch-Surbourg",
+			"ril100": "OFHLS",
+			"x": 173,
+			"y": 476,
+			"platformLength": 150,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Soultz-sous-Forêts",
+			"ril100": "OFSZ",
+			"x": 178,
+			"y": 474,
+			"platformLength": 200,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Hoffen",
+			"ril100": "OFHF",
+			"x": 186,
+			"y": 473,
+			"platformLength": 160,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Hunspach",
+			"ril100": "🇫🇷HUS",
+			"x": 188,
+			"y": 470,
+			"platformLength": 120,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Riedseltz",
+			"ril100": "OFRSZ",
+			"x": 188,
+			"y": 465,
+			"platformLength": 150,
 			"proj": 3
 		}
 	]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -12501,8 +12501,8 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Auf geht's nach %2$s, deine Fahrgäste warten schon geduldig auf dich!"
 			],
-			"stations": [ "XFSTG", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
-			"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
+			"stations": [ "XFSTG", "OFBW", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
+			"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFSGH", "OFMZS", "OFGH", "OFRHV", "OFNBN" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
@@ -13621,6 +13621,70 @@
 			],
 			"stations": [ "TWD", "TMKL", "TU" ],
 			"pathSuggestion": [ "TWD", "TRHZ", "TMKL", "TU" ],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "TER von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den TER der Linie C37+ von %s nach %s.",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Auf geht's nach %2$s, deine Fahrgäste warten schon geduldig auf dich!"
+			],
+			"objects": [
+				{
+					"stations": [ "XFSTG", "OFBW", "XFHG", "OFSZ", "XFWBG" ],
+					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFSZ", "XFWBG" ]
+				},
+				{
+					"stations": [ "XFSTG", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
+					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ]
+				},
+				{
+					"stations": [ "XFSTG", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
+					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
+					"stopsEverywhere": true,
+					"descriptions": [
+						"Fahre den TER der Linie C37 von %s nach %s.",
+						"Bring deine Fahrgäste pünktlich nach %2$s!",
+						"Fahre den TER-Bummelzug von %s nach %s."
+					]
+				}
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "TER von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den TER der Linie C35 von %s nach %s.",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre den TER-Bummelzug von %s nach %s."
+			],
+			"stations": [ "XFSTG", "OFBW", "XFHG" ],
+			"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG" ],
+			"stopsEverywhere": true,
+			"neededCapacity": [
+				{ "name": "passengers" }
+			]
+		},
+		{
+			"group": 1,
+			"name": "Strasbourg-Express von %s nach %s",
+			"service": 2,
+			"descriptions": [
+				"Fahre den grenzüberschreitenden Strasbourg-Express von %s nach %s.",
+				"Bring deine Fahrgäste pünktlich nach %2$s!",
+				"Fahre den deutsch-französischen Ausflugszug von %s nach %s."
+			],
+			"stations": [ "RN", "RND", "RMKI", "REH", "RKG", "RLA", "RWND", "RSAI", "RSFL", "RKPW", "RSHF", "XFWBG", "OFRSZ", "OFHF", "OFSZ", "OFHLS", "OFWB", "XFHG", "OFBW", "XFSTG" ],
+			"pathSuggestion": [ "RN", "RND", "RMKI", "REH", "RKG", "RLA", "RWND", "RSAI", "RSFL", "RKPW", "RSHF", "XFWBG", "OFRSZ", "OFHF", "OFSZ", "OFHLS", "OFWB", "XFHG", "OFBW", "XFVH", "XFMUM", "XFSTG" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -13634,26 +13634,8 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Auf geht's nach %2$s, deine Fahrgäste warten schon geduldig auf dich!"
 			],
-			"objects": [
-				{
-					"stations": [ "XFSTG", "OFBW", "XFHG", "OFSZ", "XFWBG" ],
-					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFSZ", "XFWBG" ]
-				},
-				{
-					"stations": [ "XFSTG", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
-					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ]
-				},
-				{
-					"stations": [ "XFSTG", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
-					"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG", "OFWB", "OFHLS", "OFSZ", "OFHF", "OFRSZ", "XFWBG" ],
-					"stopsEverywhere": true,
-					"descriptions": [
-						"Fahre den TER der Linie C37 von %s nach %s.",
-						"Bring deine Fahrgäste pünktlich nach %2$s!",
-						"Fahre den TER-Bummelzug von %s nach %s."
-					]
-				}
-			],
+			"stations": [ "XFSTG", "XFVH", "XFHG", "XFWBG" ],
+			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]
@@ -13667,8 +13649,7 @@
 				"Bring deine Fahrgäste pünktlich nach %2$s!",
 				"Fahre den TER-Bummelzug von %s nach %s."
 			],
-			"stations": [ "XFSTG", "OFBW", "XFHG" ],
-			"pathSuggestion": [ "XFSTG", "XFMUM", "XFVH", "OFBW", "XFHG" ],
+			"stations": [ "XFSTG", "XFVH", "XFHG" ],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }


### PR DESCRIPTION
Folgende Sachen werden hinzugefügt:
- Überarbeitung der Strecke Vendenheim - Haguenau - Wissembourg (alle Zwischenhalte)
- Verschiebung von Stationen Vendenheim, Wissembourg sowie Strecke Haguenau - Niederbronn auf realistischere Koordinaten
- einige TER-Tasks für die überarbeitete Strecke sowie Anpassung bestehender Tasks