### PR TITLE
Update mehrerer Stationen

### DIFF
--- a/Station.json
+++ b/Station.json
@@ -21821,7 +21821,7 @@
 			"ril100": "ESOT",
 			"x": 218,
 			"y": 30,
-			"platformLength": 275,
+			"platformLength": 220,
 			"platforms": 3,
 			"proj": 3
 		},
@@ -50488,7 +50488,7 @@
 			"ril100": "BNAU",
 			"x": 861,
 			"y": -137,
-			"platformLength": 300,
+			"platformLength": 194,
 			"platforms": 3,
 			"proj": 3
 		},
@@ -50503,7 +50503,7 @@
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Bad Wilsnack",
 			"ril100": "WWIL",
 			"x": 735,
@@ -50549,7 +50549,7 @@
 			"x": 926,
 			"y": -122,
 			"platformLength": 430,
-			"platforms": 16,
+			"platforms": 14,
 			"proj": 3
 		},
 		{
@@ -50558,7 +50558,7 @@
 			"ril100": "BHF",
 			"x": 938,
 			"y": -119,
-			"platformLength": 446,
+			"platformLength": 427,
 			"platforms": 9,
 			"proj": 3
 		},
@@ -55841,7 +55841,7 @@
 		},
 		{
 			"group": 2,
-			"name": "Fürstenwalde/Spree",
+			"name": "Fürstenwalde (Spree)",
 			"ril100": "BFUW",
 			"x": 1019,
 			"y": -95,
@@ -55890,13 +55890,11 @@
 			"proj": 3
 		},
 		{
-			"group": 2,
+			"group": 3,
 			"name": "Berlin-Köpenick",
 			"ril100": "BKP",
 			"x": 955,
 			"y": -114,
-			"platformLength": 217,
-			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -55906,16 +55904,16 @@
 			"x": 978,
 			"y": -108,
 			"platformLength": 210,
-			"platforms": 5,
+			"platforms": 4,
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Fangschleuse",
 			"ril100": "BFS",
 			"x": 988,
 			"y": -105,
-			"platformLength": 140,
+			"platformLength": 150,
 			"platforms": 2,
 			"proj": 3
 		},
@@ -55925,27 +55923,27 @@
 			"ril100": "BHGB",
 			"x": 1000,
 			"y": -104,
-			"platformLength": 140,
+			"platformLength": 170,
 			"platforms": 2,
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Berkenbrück",
 			"ril100": "BBKR",
 			"x": 1034,
 			"y": -98,
-			"platformLength": 140,
+			"platformLength": 152,
 			"platforms": 2,
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Briesen (Mark)",
 			"ril100": "BBSN",
 			"x": 1049,
 			"y": -95,
-			"platformLength": 140,
+			"platformLength": 163,
 			"platforms": 2,
 			"proj": 3
 		},
@@ -55955,17 +55953,17 @@
 			"ril100": "BJF",
 			"x": 1059,
 			"y": -92,
-			"platformLength": 141,
+			"platformLength": 163,
 			"platforms": 2,
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Pillgram",
 			"ril100": "BPIL",
 			"x": 1064,
 			"y": -93,
-			"platformLength": 142,
+			"platformLength": 163,
 			"platforms": 2,
 			"proj": 3
 		},
@@ -55975,7 +55973,7 @@
 			"ril100": "BMR",
 			"x": 1071,
 			"y": -77,
-			"platformLength": 100,
+			"platformLength": 108,
 			"platforms": 2,
 			"proj": 3
 		},
@@ -55990,12 +55988,12 @@
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Grunow (Niederlausitz)",
 			"ril100": "BGRU",
 			"x": 1063,
 			"y": -65,
-			"platformLength": 125,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56005,7 +56003,7 @@
 			"ril100": "BSB",
 			"x": 1057,
 			"y": -66,
-			"platformLength": 64,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56015,7 +56013,7 @@
 			"ril100": "BOEG",
 			"x": 1049,
 			"y": -66,
-			"platformLength": 82,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56040,12 +56038,12 @@
 			"proj": 3
 		},
 		{
-			"group": 5,
+			"group": 2,
 			"name": "Lindenberg (Mark)",
 			"ril100": "BLNG",
 			"x": 1027,
 			"y": -71,
-			"platformLength": 100,
+			"platformLength": 94,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56065,7 +56063,7 @@
 			"ril100": "BHUB",
 			"x": 1007,
 			"y": -77,
-			"platformLength": 73,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56085,7 +56083,7 @@
 			"ril100": "BKUM",
 			"x": 995,
 			"y": -83,
-			"platformLength": 72,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56105,7 +56103,7 @@
 			"ril100": "BKAB",
 			"x": 975,
 			"y": -87,
-			"platformLength": 77,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56125,7 +56123,7 @@
 			"ril100": "BNDL",
 			"x": 965,
 			"y": -87,
-			"platformLength": 84,
+			"platformLength": 105,
 			"platforms": 1,
 			"proj": 3
 		},
@@ -56630,13 +56628,11 @@
 			"proj": 3
 		},
 		{
-			"group": 2,
+			"group": 6,
 			"name": "Friedrichsruh",
 			"ril100": "AFRD",
 			"x": 521,
 			"y": -286,
-			"platformLength": 110,
-			"platforms": 2,
 			"proj": 3
 		},
 		{
@@ -57283,8 +57279,8 @@
 			"group": 0,
 			"x": -54,
 			"y": 357,
-			"platformLength": 374,
-			"platforms": 8,
+			"platformLength": 423,
+			"platforms": 13,
 			"proj": 3
 		},
 		{
@@ -74080,11 +74076,11 @@
 		{
 			"name": "Devínske Jazero",
 			"ril100": "🇸🇰O682295722",
-			"group": 2,
+			"group": 5,
 			"x": 1437,
 			"y": 584,
-			"platformLength": 195,
-			"platforms": 1,
+			"platformLength": 240,
+			"platforms": 2,
 			"proj": 3
 		},
 		{


### PR DESCRIPTION
Update von:
- Luxembourg (Bahnsteiganzahl und Länge)
- Devínske Jazero (zu Hp degradiert, Bahnsteiganzahl und Länge)
- Soest (Bahnsteiglänge)
- Strecke BKW-BFP (einige Stops zu Bf befördert, Bahnsteiglänge an mehreren Stops angepasst)
- Strecke BFP-BL (Köpenick zum Betriebsbahnhof degradiert, einige Stops zu Bf befördert, Bahnsteiglänge an mehreren Stops, Bahnsteiganzahl in BL geändert)
- Strecke BSPD-AH (Bad Wilsnack zum Bf befördert, Friedrichsruh zum Wegpunkt degradiert)