### PR TITLE
Verlegung Weddeler Schleife

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -46557,7 +46557,7 @@
 			"electrified": true,
 			"objects": [
 				{
-					"start": "HWOB",
+					"start": "HF",
 					"end": "HBS",
 					"maxSpeed": 160,
 					"twistingFactor": 0.4,

--- a/Station.json
+++ b/Station.json
@@ -92339,7 +92339,7 @@
 			"ril100": "HF",
 			"x": 572,
 			"y": -108,
-			"platformLength": 165,
+			"platformLength": 186,
 			"platforms": 4,
 			"proj": 3
 		},

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -27,7 +27,7 @@
 				},
 				{
 					"stations": [ "XSIO", "XSSP", "XSTH", "XSBE", "XSOL", "XSB", "RB", "RF", "RO", "RK", "RM", "FF", "FH", "FFU", "FKW", "HG", "HH", "HWOB", "BL", "BHF" ],
-					"pathSuggestion": [ "XSIO", "XSSP", "XSTH", "XSBE", "🇨🇭WANZ", "🇨🇭RTR", "XSOL", "XSB", "RB", "RML", "RF", "RO", "RAP", "RRA", "RK", "RGN", "RSAB", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FKW", "HG", "HH", "HLER", "HWOB", "LS", "BSPD", "BL", "BHF" ]
+					"pathSuggestion": [ "XSIO", "XSSP", "XSTH", "XSBE", "🇨🇭WANZ", "🇨🇭RTR", "XSOL", "XSB", "RB", "RML", "RF", "RO", "RAP", "RRA", "RK", "RGN", "RSAB", "RM", "FBL", "FDG", "FFLF", "FF", "FH", "FFD", "FFU", "FKW", "HG", "HH", "HLER", "HF", "HWOB", "LS", "BSPD", "BL", "BHF" ]
 				},
 				{
 					"stations": [ "TS", "RM", "FFLF", "FF", "FKW", "HG", "HH", "AH" ],
@@ -75,7 +75,7 @@
 				},
 				{
 					"stations": [ "BL", "BSPD", "KK", "KB" ],
-					"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EHG", "KW", "KSO", "KK", "KKAS", "KB" ]
+					"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EHG", "KW", "KSO", "KK", "KKAS", "KB" ]
 				}
 			],
 			"neededCapacity": [
@@ -1986,7 +1986,7 @@
 				"Stelle eine West-Ost-Verbindung zwischen der Hauptstadt von Deutschland und den Niederlanden her."
 			],
 			"stations": [ "BL", "BSPD", "LS", "HH", "HO", "HR", "XNHL", "🇳🇱Aml", "🇳🇱Dv", "🇳🇱Amf", "🇳🇱Hvs", "XNAC" ],
-			"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HWUN", "HM", "HL", "HO", "HR", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Apd", "🇳🇱Amf", "🇳🇱Hvs", "🇳🇱Wp", "XNAC" ],
+			"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HWUN", "HM", "HL", "HO", "HR", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Apd", "🇳🇱Amf", "🇳🇱Hvs", "🇳🇱Wp", "XNAC" ],
 			"neededCapacity": [
 				{ "name": "passengers" },
 				{ "name": "bistroseats" }
@@ -5755,7 +5755,7 @@
 				},
 				{
 					"stations": [ "BOD", "XFMVC" ],
-					"pathSuggestion": [ "BOD", "BKW", "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EHG", "KW", "KSO", "KK", "KDN", "KA", "XBHE", "XBLIG", "XBB", "XFLIE", "🇫🇷RUX", "XFSVF", "XFVAR", "XFMVC" ]
+					"pathSuggestion": [ "BOD", "BKW", "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EHG", "KW", "KSO", "KK", "KDN", "KA", "XBHE", "XBLIG", "XBB", "XFLIE", "🇫🇷RUX", "XFSVF", "XFVAR", "XFMVC" ]
 				}
 			],
 			"neededCapacity": [
@@ -6359,11 +6359,11 @@
 				},
 				{
 					"stations": [ "BFBI", "FFLF" ],
-					"pathSuggestion": [ "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HG", "FKW", "FFU", "FFD", "FH", "FF", "FFLF" ]
+					"pathSuggestion": [ "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HG", "FKW", "FFU", "FFD", "FH", "FF", "FFLF" ]
 				},
 				{
 					"stations": [ "BFBI", "KDFF" ],
-					"pathSuggestion": [ "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EDO", "EE", "EDG", "KDFF" ]
+					"pathSuggestion": [ "BFBI", "BBF", "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HWUN", "HM", "HL", "EHFD", "EBILP", "EHM", "EDO", "EE", "EDG", "KDFF" ]
 				},
 				{
 					"stations": [ "FFLF", "KDFF" ],
@@ -6442,7 +6442,7 @@
 				"Die Reisenden wollen schnell in ihr Hotel am Zielort %2$s."
 			],
 			"stations": [ "XVS", "XVM", "XDKH", "HBTH", "BL", "DH" ],
-			"pathSuggestion": [ "XVS", "XVAJ", "🇸🇪HD", "🇸🇪JN", "XVFN", "XVK", "XVNC", "XVL", "XVMJ", "XVN", "XVAL", "XVHH", "XVEV", "XVLD", "XVM", "XDKH", "XDRI", "XDMF", "XDTA", "XDLU", "XDTI", "AF", "AJ", "AR", "AN", "AEL", "AH", "AHAR", "ABLZ", "AROG", "HB", "HO", "HR", "HBTH", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Zp", "XNAH", "🇳🇱Zv", "EOB", "EDG", "EE", "EDO", "EHM", "EBILP", "EHFD", "HL", "HM", "HWUN", "HH", "HLER", "HWOB", "LS", "BSPD", "BL", "BBF", "BDKO", "BEW", "DGB", "DH" ],
+			"pathSuggestion": [ "XVS", "XVAJ", "🇸🇪HD", "🇸🇪JN", "XVFN", "XVK", "XVNC", "XVL", "XVMJ", "XVN", "XVAL", "XVHH", "XVEV", "XVLD", "XVM", "XDKH", "XDRI", "XDMF", "XDTA", "XDLU", "XDTI", "AF", "AJ", "AR", "AN", "AEL", "AH", "AHAR", "ABLZ", "AROG", "HB", "HO", "HR", "HBTH", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Zp", "XNAH", "🇳🇱Zv", "EOB", "EDG", "EE", "EDO", "EHM", "EBILP", "EHFD", "HL", "HM", "HWUN", "HH", "HLER", "HF", "HWOB", "LS", "BSPD", "BL", "BBF", "BDKO", "BEW", "DGB", "DH" ],
 			"neededCapacity": [
 				{ "name": "beds" }
 			]
@@ -7384,7 +7384,7 @@
 				},
 				{
 					"stations": [ "BL", "FF", "XFSTG", "XLL", "XBB", "XNAC", "AH", "XDKH", "XVS" ],
-					"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HG", "FKW", "FFU", "FFD", "FH", "FF", "FD", "RMF", "RM", "RSAB", "RGN", "RK", "RRA", "RAP", "XFSTG", "XFVH", "XFMH", "XFRD", "XFN", "XFFD", "XFPS", "XFMZV", "XFTHV", "XLB", "XLL", "XBAR", "XBLBM", "XBMR", "XBNA", "XBB", "🇳🇱Zlw", "🇳🇱Brd", "XNRC", "XNSP", "XNAC", "XNU", "XNAH", "🇳🇱Zv", "EOB", "EG", "EMST", "HO", "HB", "AROG", "ABLZ", "AHAR", "AH", "AEL", "AN", "AR", "AJ", "AF", "XDTI", "XDLU", "XDTA", "XDMF", "XDRI", "XDKH", "XVM", "XVLD", "XVEV", "XVHH", "XVAL", "XVN", "XVMJ", "XVL", "XVNC", "🇸🇪JN", "🇸🇪HD", "XVAJ", "XVS" ]
+					"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HG", "FKW", "FFU", "FFD", "FH", "FF", "FD", "RMF", "RM", "RSAB", "RGN", "RK", "RRA", "RAP", "XFSTG", "XFVH", "XFMH", "XFRD", "XFN", "XFFD", "XFPS", "XFMZV", "XFTHV", "XLB", "XLL", "XBAR", "XBLBM", "XBMR", "XBNA", "XBB", "🇳🇱Zlw", "🇳🇱Brd", "XNRC", "XNSP", "XNAC", "XNU", "XNAH", "🇳🇱Zv", "EOB", "EG", "EMST", "HO", "HB", "AROG", "ABLZ", "AHAR", "AH", "AEL", "AN", "AR", "AJ", "AF", "XDTI", "XDLU", "XDTA", "XDMF", "XDRI", "XDKH", "XVM", "XVLD", "XVEV", "XVHH", "XVAL", "XVN", "XVMJ", "XVL", "XVNC", "🇸🇪JN", "🇸🇪HD", "XVAJ", "XVS" ]
 				},
 				{
 					"stations": [ "XFSTG", "XSBE", "XIMB", "XIVP", "XAWW", "XMBK", "XJBC", "ZAS", "XGT", "XWS", "XQIS" ],
@@ -10718,7 +10718,7 @@
 				},
 				{
 					"stations": [ "BHF", "BL", "BSPD", "HWOB", "HH", "EPD", "EHM", "EDO", "EBO", "EE", "EDG", "KD", "KK", "KDN", "KA" ],
-					"pathSuggestion": [ "BHF", "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HHM", "HA", "EPD", "EHM", "EDO", "EBO", "EE", "EDG", "KDFF", "KD", "KK", "KHR", "KDN", "KA" ]
+					"pathSuggestion": [ "BHF", "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HHM", "HA", "EPD", "EHM", "EDO", "EBO", "EE", "EDG", "KDFF", "KD", "KK", "KHR", "KDN", "KA" ]
 				}
 			],
 			"neededCapacity": [
@@ -10738,7 +10738,7 @@
 			"objects": [
 				{
 					"stations": [ "TS", "RH", "FD", "FMZ", "FF", "FO", "FH", "FFU", "FKW", "HG", "HHI", "HBS", "HWOB", "BSPD", "BL" ],
-					"pathSuggestion": [ "TS", "TV", "RBR", "RH", "RMF", "FBH", "FD", "FDG", "FMB", "FMZ", "FW", "FHOE", "FF", "FO", "FH", "FGEL", "FFD", "FFU", "FKW", "HG", "HN", "HK", "HELZ", "HHI", "HBS", "HWOB", "LS", "BSPD", "BL" ]
+					"pathSuggestion": [ "TS", "TV", "RBR", "RH", "RMF", "FBH", "FD", "FDG", "FMB", "FMZ", "FW", "FHOE", "FF", "FO", "FH", "FGEL", "FFD", "FFU", "FKW", "HG", "HN", "HK", "HELZ", "HHI", "HBS", "HF", "HWOB", "LS", "BSPD", "BL" ]
 				}
 			],
 			"neededCapacity": [
@@ -12094,7 +12094,7 @@
 				"Nutze ICE3neo anstelle ICE L, um diese Leistung überhaupt noch anbieten zu können."
 			],
 			"stations": [ "BL", "BSPD", "HH", "HBDE", "HO", "HR", "HBTH", "XNHL", "🇳🇱Dv", "🇳🇱Apd", "🇳🇱Amf", "🇳🇱Hvs", "XNAC" ],
-			"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HLER", "HH", "HWUN", "HM", "HL", "HBDE", "HO", "HR", "HBTH", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Apd", "🇳🇱Amf", "🇳🇱Hvs", "🇳🇱Wp", "XNAC" ],
+			"pathSuggestion": [ "BL", "BSPD", "LS", "HWOB", "HF", "HLER", "HH", "HWUN", "HM", "HL", "HBDE", "HO", "HR", "HBTH", "XNHL", "🇳🇱Aml", "🇳🇱Wdn", "🇳🇱Dv", "🇳🇱Apd", "🇳🇱Amf", "🇳🇱Hvs", "🇳🇱Wp", "XNAC" ],
 			"neededCapacity": [
 				{ "name": "passengers" }
 			]


### PR DESCRIPTION
Verlegung Ende der Weddeler Schleife von Wolfsburg nach Fallersleben, Bahnsteiglänge Fallersleben angepasst