### PR TITLE
Südfrankreich 6/6

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -22041,7 +22041,7 @@
 			"electrified": true,
 			"neededEquipments": [
 				"FR",
-				"ETCS"
+				"TVM"
 			],
 			"group": 2,
 			"maxSpeed": 300,
@@ -22051,11 +22051,7 @@
 				{
 					"start": "🇫🇷CSP",
 					"end": "XFCOB",
-					"length": 51,
-					"neededEquipments": [
-						"FR",
-						"ETCS"
-					]
+					"length": 51
 				},
 				{
 					"start": "XFCOB",

--- a/Path.json
+++ b/Path.json
@@ -6052,6 +6052,93 @@
 			]
 		},
 		{
+			"name": "Ligne du Monastier à La Bastide-Saint-Laurent-les-Bains",
+			"electrified": false,
+			"group": 1,
+			"neededEquipments": [
+				"FR"
+			],
+			"objects": [
+				{
+					"start": "🇫🇷LMR",
+					"end": "🇫🇷SQL",
+					"length": 5,
+					"maxSpeed": 60,
+					"twistingFactor": 0.4
+				},
+				{
+					"start": "🇫🇷SQL",
+					"end": "🇫🇷CNA",
+					"length": 5,
+					"maxSpeed": 60,
+					"twistingFactor": 0.23
+				},
+				{
+					"start": "🇫🇷CNA",
+					"end": "🇫🇷BWQ",
+					"length": 1,
+					"maxSpeed": 60,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷BWQ",
+					"end": "🇫🇷BJC",
+					"length": 5,
+					"maxSpeed": 60,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "🇫🇷BJC",
+					"end": "🇫🇷O521515549",
+					"length": 5,
+					"maxSpeed": 60,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "🇫🇷O521515549",
+					"end": "🇫🇷MDE",
+					"length": 7,
+					"maxSpeed": 60,
+					"twistingFactor": 0.32
+				},
+				{
+					"start": "🇫🇷MDE",
+					"end": "🇫🇷BCT",
+					"length": 13,
+					"maxSpeed": 40,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷BCT",
+					"end": "🇫🇷AEN",
+					"length": 3,
+					"maxSpeed": 50,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "🇫🇷AEN",
+					"end": "🇫🇷BVZ",
+					"length": 11,
+					"maxSpeed": 70,
+					"twistingFactor": 0.47
+				},
+				{
+					"start": "🇫🇷BVZ",
+					"end": "🇫🇷CJD",
+					"length": 9,
+					"maxSpeed": 70,
+					"twistingFactor": 0.38
+				},
+				{
+					"start": "🇫🇷CJD",
+					"end": "XFLBS",
+					"length": 8,
+					"maxSpeed": 80,
+					"twistingFactor": 0.36
+				}
+			]
+		},
+		{
 			"group": 2,
 			"name": "Hannover-Würzburg",
 			"twistingFactor": 0.05,
@@ -12672,14 +12759,6 @@
 					"length": 40,
 					"twistingFactor": 0.26,
 					"maxSpeed": 140
-				},
-				{
-					"name": "Ligne de Saint-Germain-des-Fossés à Nîmes-Courbessac",
-					"start": "🇫🇷RIO",
-					"end": "XFCLE",
-					"length": 13,
-					"twistingFactor": 0.2,
-					"maxSpeed": 160
 				}
 			]
 		},
@@ -24284,6 +24363,147 @@
 			"start": "HELZ",
 			"end": "HHI",
 			"twistingFactor": 0.25
+		},
+		{
+			"neededEquipments": [
+				"FR"
+			],
+			"group": 1,
+			"name": "Ligne de Saint-Germain-des-Fossés à Nîmes",
+			"electrified": false,
+			"objects": [
+				{
+					"start": "XFARV",
+					"end": "XFBRD",
+					"group": 0,
+					"length": 10,
+					"maxSpeed": 130,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "XFBRD",
+					"end": "🇫🇷SGA",
+					"group": 0,
+					"length": 23,
+					"maxSpeed": 130,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷SGA",
+					"end": "XFLNC",
+					"group": 0,
+					"length": 7,
+					"maxSpeed": 95,
+					"twistingFactor": 0.25
+				},
+				{
+					"start": "XFLNC",
+					"end": "XFMNR",
+					"length": 23,
+					"maxSpeed": 95,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "XFMNR",
+					"end": "🇫🇷AES",
+					"length": 9,
+					"maxSpeed": 75,
+					"twistingFactor": 0.55
+				},
+				{
+					"start": "🇫🇷AES",
+					"end": "XFCPX",
+					"length": 13,
+					"maxSpeed": 40,
+					"twistingFactor": 0.36
+				},
+				{
+					"start": "XFCPX",
+					"end": "XFLGG",
+					"length": 19,
+					"maxSpeed": 70,
+					"twistingFactor": 0.36
+				},
+				{
+					"start": "XFLGG",
+					"end": "🇫🇷O9955065545",
+					"length": 12,
+					"maxSpeed": 80,
+					"twistingFactor": 0.38
+				},
+				{
+					"start": "🇫🇷O9955065545",
+					"end": "XFLBS",
+					"length": 7,
+					"maxSpeed": 80,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "XFLBS",
+					"end": "XFVLF",
+					"length": 20,
+					"maxSpeed": 80,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "XFVLF",
+					"end": "XFGNC",
+					"length": 12,
+					"maxSpeed": 75,
+					"twistingFactor": 0.31
+				},
+				{
+					"start": "XFGNC",
+					"end": "🇫🇷CBO",
+					"length": 7,
+					"maxSpeed": 75,
+					"twistingFactor": 0.35
+				},
+				{
+					"start": "🇫🇷CBO",
+					"end": "🇫🇷SCZ",
+					"length": 5,
+					"maxSpeed": 55,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "🇫🇷SCZ",
+					"end": "🇫🇷LLE",
+					"length": 4,
+					"maxSpeed": 55,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇫🇷LLE",
+					"end": "🇫🇷O425322098",
+					"length": 2,
+					"maxSpeed": 80,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "🇫🇷O425322098",
+					"end": "XFALE",
+					"length": 13,
+					"maxSpeed": 60,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "XFALE",
+					"end": "🇫🇷XGE",
+					"group": 0,
+					"length": 24,
+					"maxSpeed": 120,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷XGE",
+					"end": "🇫🇷NMS",
+					"group": 0,
+					"length": 23,
+					"maxSpeed": 120,
+					"twistingFactor": 0.38
+				}
+			]
 		},
 		{
 			"name": "Bohusbanan",
@@ -73445,7 +73665,7 @@
 				"FR"
 			],
 			"electrified": false,
-			"name": "Ligne de Saint-Germain-des-Fossés à Nîmes-Courbessac",
+			"name": "Ligne de Saint-Germain-des-Fossés à Nîmes",
 			"objects": [
 				{
 					"start": "XFARV",
@@ -73516,6 +73736,14 @@
 					"length": 3,
 					"maxSpeed": 140,
 					"twistingFactor": 0.29
+				},
+				{
+					"start": "XFCLE",
+					"end": "🇫🇷RIO",
+					"length": 13,
+					"twistingFactor": 0.2,
+					"maxSpeed": 160,
+					"electrified": true
 				}
 			]
 		},

--- a/Path.json
+++ b/Path.json
@@ -84013,6 +84013,74 @@
 			]
 		},
 		{
+			"name": "Ligne des Sables-d'Olonne à Tours",
+			"group": 1,
+			"neededEquipments": [
+				"FR"
+			],
+			"maxSpeed": 100,
+			"electrified": false,
+			"objects": [
+				{
+					"start": "🇫🇷LSO",
+					"end": "🇫🇷OSM",
+					"length": 5,
+					"twistingFactor": 0.01,
+					"electrified": true,
+					"group": 0,
+					"maxSpeed": 110
+				},
+				{
+					"start": "🇫🇷OSM",
+					"end": "XFLEH",
+					"length": 10,
+					"twistingFactor": 0.12,
+					"electrified": true,
+					"group": 0,
+					"maxSpeed": 110
+				},
+				{
+					"start": "XFLEH",
+					"end": "XFLRY",
+					"length": 19,
+					"twistingFactor": 0.13,
+					"electrified": true,
+					"group": 0,
+					"maxSpeed": 110
+				},
+				{
+					"start": "XFLRY",
+					"end": "🇫🇷CTO",
+					"length": 34,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷CTO",
+					"end": "🇫🇷PZK",
+					"length": 22,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷PZK",
+					"end": "🇫🇷CEZ",
+					"length": 14,
+					"twistingFactor": 0.22
+				},
+				{
+					"start": "🇫🇷CEZ",
+					"end": "🇫🇷BRS",
+					"length": 14,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷BRS",
+					"end": "🇫🇷THQ",
+					"length": 29,
+					"twistingFactor": 0.19
+				}
+			]
+		},
+		{
 			"name": "Timișoara - Arad",
 			"group": 0,
 			"maxSpeed": 70,

--- a/Path.json
+++ b/Path.json
@@ -73726,13 +73726,47 @@
 					"length": 3,
 					"maxSpeed": 140,
 					"twistingFactor": 0.29
+				}
+			]
+		},
+		{
+			"name": "Ligne de Saint-Germain-des-Fossés à Nîmes",
+			"maxSpeed": 160,
+			"neededEquipments": [
+				"FR"
+			],
+			"electrified": false,
+			"group": 1,
+			"objects": [
+				{
+					"start": "XFSGF",
+					"end": "XFGAN",
+					"length": 23,
+					"twistingFactor": 0.21
+				},
+				{
+					"start": "XFGAN",
+					"end": "🇫🇷AGE",
+					"length": 10,
+					"twistingFactor": 0.29
+				},
+				{
+					"start": "🇫🇷AGE",
+					"end": "🇫🇷PMT",
+					"length": 9,
+					"twistingFactor": 0.18
+				},
+				{
+					"start": "🇫🇷PMT",
+					"end": "🇫🇷RIO",
+					"length": 6,
+					"twistingFactor": 0.15
 				},
 				{
 					"start": "XFCLE",
 					"end": "🇫🇷RIO",
 					"length": 13,
 					"twistingFactor": 0.2,
-					"maxSpeed": 160,
 					"electrified": true
 				}
 			]

--- a/Path.json
+++ b/Path.json
@@ -22041,7 +22041,7 @@
 			"electrified": true,
 			"neededEquipments": [
 				"FR",
-				"TVM"
+				"ETCS"
 			],
 			"group": 2,
 			"maxSpeed": 300,
@@ -22051,7 +22051,11 @@
 				{
 					"start": "🇫🇷CSP",
 					"end": "XFCOB",
-					"length": 51
+					"length": 51,
+					"neededEquipments": [
+						"FR",
+						"ETCS"
+					]
 				},
 				{
 					"start": "XFCOB",

--- a/Path.json
+++ b/Path.json
@@ -38014,22 +38014,7 @@
 			]
 		},
 		{
-			"electrified": true,
-			"group": 0,
-			"neededEquipments": [
-				"FR"
-			],
-			"twistingFactor": 0.2,
-			"objects": [
-				{
-					"start": "XFARL",
-					"end": "🇫🇷NPG",
-					"length": 28,
-					"maxSpeed": 160
-				}
-			]
-		},
-		{
+			"name": "Ligne de Tarascon à Sète",
 			"electrified": true,
 			"group": 0,
 			"maxSpeed": 160,
@@ -38038,6 +38023,12 @@
 				"FR"
 			],
 			"objects": [
+				{
+					"twistingFactor": 0.2,
+					"start": "XFARL",
+					"end": "🇫🇷NPG",
+					"length": 28
+				},
 				{
 					"start": "🇫🇷NPG",
 					"end": "🇫🇷NMS",
@@ -38062,10 +38053,23 @@
 					"start": "XFMO",
 					"end": "🇫🇷VLM",
 					"length": 7
+				},
+				{
+					"twistingFactor": 0.17,
+					"start": "🇫🇷VLM",
+					"end": "🇫🇷FRN",
+					"length": 13
+				},
+				{
+					"twistingFactor": 0.17,
+					"start": "🇫🇷FRN",
+					"end": "XFSE",
+					"length": 6
 				}
 			]
 		},
 		{
+			"name": "Ligne de Bordeaux à Sète",
 			"electrified": true,
 			"group": 0,
 			"maxSpeed": 160,
@@ -38075,41 +38079,26 @@
 			],
 			"objects": [
 				{
-					"start": "🇫🇷VLM",
-					"end": "🇫🇷FRN",
-					"length": 13
-				},
-				{
-					"start": "🇫🇷FRN",
-					"end": "XFSE",
-					"length": 6
-				},
-				{
-					"name": "Ligne de Bordeaux à Sète",
 					"start": "XFSE",
 					"end": "🇫🇷78129",
 					"length": 17
 				},
 				{
-					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷78129",
 					"end": "🇫🇷VA",
 					"length": 9
 				},
 				{
-					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷VA",
 					"end": "XFBZ",
 					"length": 17
 				},
 				{
-					"name": "Ligne de Bordeaux à Sète",
 					"start": "XFBZ",
 					"end": "🇫🇷CBS",
 					"length": 7
 				},
 				{
-					"name": "Ligne de Bordeaux à Sète",
 					"start": "🇫🇷CBS",
 					"end": "XFNB",
 					"length": 18
@@ -38126,7 +38115,6 @@
 				"FR"
 			],
 			"objects": [
-				{
 				{
 					"start": "XFNB",
 					"end": "🇫🇷PLN",

--- a/Path.json
+++ b/Path.json
@@ -20698,6 +20698,100 @@
 			]
 		},
 		{
+			"name": "Ligne de Saint-Benoît à La Rochelle-Ville",
+			"electrified": true,
+			"neededEquipments": [
+				"FR"
+			],
+			"group": 0,
+			"objects": [
+				{
+					"start": "🇫🇷O2985684668",
+					"end": "🇫🇷48518",
+					"length": 10,
+					"maxSpeed": 140,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "🇫🇷48518",
+					"end": "🇫🇷48519",
+					"length": 5,
+					"maxSpeed": 140,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷48519",
+					"end": "🇫🇷SGE",
+					"length": 14,
+					"maxSpeed": 140,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷SGE",
+					"end": "🇫🇷MAZ",
+					"length": 12,
+					"maxSpeed": 140,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷MAZ",
+					"end": "🇫🇷NRT",
+					"length": 21,
+					"maxSpeed": 140,
+					"twistingFactor": 0.08
+				},
+				{
+					"start": "🇫🇷NRT",
+					"end": "🇫🇷CCK",
+					"length": 13,
+					"maxSpeed": 160,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷CCK",
+					"end": "🇫🇷O2718046618",
+					"length": 9,
+					"maxSpeed": 120,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷O2718046618",
+					"end": "XFLHY",
+					"length": 7,
+					"maxSpeed": 140,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "XFLHY",
+					"end": "🇫🇷PAP",
+					"length": 6,
+					"maxSpeed": 160,
+					"twistingFactor": 0.17
+				},
+				{
+					"start": "🇫🇷PAP",
+					"end": "🇫🇷RIL",
+					"length": 7,
+					"maxSpeed": 160,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷RIL",
+					"end": "🇫🇷LUI",
+					"length": 6,
+					"maxSpeed": 160,
+					"twistingFactor": 0.03
+				},
+				{
+					"start": "🇫🇷LUI",
+					"end": "XFPT",
+					"length": 26,
+					"maxSpeed": 140,
+					"twistingFactor": 0.18
+				}
+			]
+		},
+		{
 			"group": 0,
 			"electrified": false,
 			"twistingFactor": 0.4,

--- a/Path.json
+++ b/Path.json
@@ -2469,7 +2469,7 @@
 			]
 		},
 		{
-			"name": "Ligne de Chartres à Bordeaux-Saint-Jean",
+			"name": "Ligne de Chartres à Bordeaux",
 			"neededEquipments": [
 				"FR"
 			],
@@ -11477,22 +11477,6 @@
 					"end": "🇫🇷BDC",
 					"length": 9,
 					"maxSpeed": 150
-				}
-			]
-		},
-		{
-			"electrified": true,
-			"group": 0,
-			"neededEquipments": [
-				"FR"
-			],
-			"twistingFactor": 0.2,
-			"objects": [
-				{
-					"start": "XFARL",
-					"end": "🇫🇷NPG",
-					"length": 28,
-					"maxSpeed": 160
 				}
 			]
 		},
@@ -32243,42 +32227,6 @@
 		},
 		{
 			"electrified": true,
-			"group": 0,
-			"maxSpeed": 160,
-			"twistingFactor": 0.22,
-			"neededEquipments": [
-				"FR"
-			],
-			"objects": [
-				{
-					"start": "🇫🇷NPG",
-					"end": "🇫🇷NMS",
-					"length": 15
-				},
-				{
-					"start": "🇫🇷NMS",
-					"end": "🇫🇷VZC",
-					"length": 16
-				},
-				{
-					"start": "🇫🇷VZC",
-					"end": "XFLUN",
-					"length": 10
-				},
-				{
-					"start": "XFLUN",
-					"end": "XFMO",
-					"length": 23
-				},
-				{
-					"start": "XFMO",
-					"end": "🇫🇷VLM",
-					"length": 7
-				}
-			]
-		},
-		{
-			"electrified": true,
 			"group": 2,
 			"maxSpeed": 300,
 			"twistingFactor": 0.18,
@@ -38068,6 +38016,58 @@
 		{
 			"electrified": true,
 			"group": 0,
+			"neededEquipments": [
+				"FR"
+			],
+			"twistingFactor": 0.2,
+			"objects": [
+				{
+					"start": "XFARL",
+					"end": "🇫🇷NPG",
+					"length": 28,
+					"maxSpeed": 160
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
+			"maxSpeed": 160,
+			"twistingFactor": 0.22,
+			"neededEquipments": [
+				"FR"
+			],
+			"objects": [
+				{
+					"start": "🇫🇷NPG",
+					"end": "🇫🇷NMS",
+					"length": 15
+				},
+				{
+					"start": "🇫🇷NMS",
+					"end": "🇫🇷VZC",
+					"length": 16
+				},
+				{
+					"start": "🇫🇷VZC",
+					"end": "XFLUN",
+					"length": 10
+				},
+				{
+					"start": "XFLUN",
+					"end": "XFMO",
+					"length": 23
+				},
+				{
+					"start": "XFMO",
+					"end": "🇫🇷VLM",
+					"length": 7
+				}
+			]
+		},
+		{
+			"electrified": true,
+			"group": 0,
 			"maxSpeed": 160,
 			"twistingFactor": 0.17,
 			"neededEquipments": [
@@ -38113,9 +38113,21 @@
 					"start": "🇫🇷CBS",
 					"end": "XFNB",
 					"length": 18
-				},
+				}
+			]
+		},
+		{
+			"name": "Ligne de Narbonne à Port-Bou",
+			"electrified": true,
+			"group": 0,
+			"maxSpeed": 160,
+			"twistingFactor": 0.17,
+			"neededEquipments": [
+				"FR"
+			],
+			"objects": [
 				{
-					"name": "Ligne de Narbonne à Port-Bou",
+				{
 					"start": "XFNB",
 					"end": "🇫🇷PLN",
 					"length": 21,
@@ -38123,14 +38135,12 @@
 					"twistingFactor": 0.2
 				},
 				{
-					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷PLN",
 					"end": "🇫🇷78108",
 					"length": 10,
 					"maxSpeed": 150
 				},
 				{
-					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷78108",
 					"end": "🇫🇷78415",
 					"length": 14,
@@ -38138,14 +38148,12 @@
 					"twistingFactor": 0.2
 				},
 				{
-					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "🇫🇷78415",
 					"end": "XFRV",
 					"length": 9,
 					"maxSpeed": 150
 				},
 				{
-					"name": "Ligne de Narbonne à Port-Bou",
 					"start": "XFRV",
 					"end": "XFPE",
 					"length": 8,

--- a/Path.json
+++ b/Path.json
@@ -2469,6 +2469,99 @@
 			]
 		},
 		{
+			"name": "Ligne de Chartres à Bordeaux-Saint-Jean",
+			"neededEquipments": [
+				"FR"
+			],
+			"electrified": false,
+			"group": 1,
+			"maxSpeed": 100,
+			"objects": [
+				{
+					"start": "XFSAS",
+					"end": "🇫🇷SBZ",
+					"length": 14,
+					"twistingFactor": 0.19
+				},
+				{
+					"start": "🇫🇷SBZ",
+					"end": "🇫🇷SJA",
+					"length": 10,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "🇫🇷SJA",
+					"end": "🇫🇷LLY",
+					"length": 12,
+					"twistingFactor": 0.16
+				},
+				{
+					"start": "🇫🇷LLY",
+					"end": "🇫🇷VVK",
+					"length": 6,
+					"twistingFactor": 0.11
+				},
+				{
+					"start": "🇫🇷VVK",
+					"end": "🇫🇷PIH",
+					"length": 6,
+					"twistingFactor": 0.14
+				},
+				{
+					"start": "🇫🇷PIH",
+					"end": "🇫🇷BVK",
+					"length": 3,
+					"twistingFactor": 0.06
+				},
+				{
+					"start": "🇫🇷BVK",
+					"end": "🇫🇷MRJ",
+					"length": 3,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷MRJ",
+					"end": "🇫🇷FOW",
+					"length": 4,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷FOW",
+					"end": "🇫🇷NRT",
+					"length": 10,
+					"twistingFactor": 0.15
+				},
+				{
+					"start": "🇫🇷NRT",
+					"end": "🇫🇷48717",
+					"length": 44,
+					"maxSpeed": 40,
+					"twistingFactor": 0.22
+				},
+				{
+					"start": "🇫🇷48717",
+					"end": "🇫🇷THQ",
+					"length": 45,
+					"maxSpeed": 60,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "🇫🇷THQ",
+					"end": "XFMBE",
+					"electrified": true,
+					"length": 17,
+					"twistingFactor": 0.2
+				},
+				{
+					"start": "XFMBE",
+					"end": "XFSUD",
+					"electrified": true,
+					"length": 21,
+					"twistingFactor": 0.35
+				}
+			]
+		},
+		{
 			"group": 0,
 			"neededEquipments": [
 				"FR"

--- a/Path.json
+++ b/Path.json
@@ -38116,7 +38116,6 @@
 			"name": "Ligne de Narbonne à Port-Bou",
 			"electrified": true,
 			"group": 0,
-			"maxSpeed": 160,
 			"twistingFactor": 0.17,
 			"neededEquipments": [
 				"FR"

--- a/Path.json
+++ b/Path.json
@@ -38153,6 +38153,55 @@
 					"end": "XFPE",
 					"length": 8,
 					"maxSpeed": 150
+				},
+				{
+					"start": "XFPE",
+					"end": "XFEL",
+					"length": 13,
+					"maxSpeed": 140,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "XFEL",
+					"end": "XFAR",
+					"length": 9,
+					"maxSpeed": 140,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "XFAR",
+					"end": "XFCLL",
+					"length": 5,
+					"maxSpeed": 140,
+					"twistingFactor": 0.12
+				},
+				{
+					"start": "XFCLL",
+					"end": "🇫🇷POV",
+					"length": 2,
+					"maxSpeed": 140,
+					"twistingFactor": 0.13
+				},
+				{
+					"start": "🇫🇷POV",
+					"end": "XFBAY",
+					"length": 4,
+					"maxSpeed": 100,
+					"twistingFactor": 0.33
+				},
+				{
+					"start": "XFBAY",
+					"end": "XFCE",
+					"length": 6,
+					"maxSpeed": 100,
+					"twistingFactor": 0.3
+				},
+				{
+					"start": "XFCE",
+					"end": "🇪🇸O3950732005",
+					"length": 1,
+					"maxSpeed": 40,
+					"twistingFactor": 0.01
 				}
 			]
 		},

--- a/Path.json
+++ b/Path.json
@@ -81462,6 +81462,58 @@
 			]
 		},
 		{
+			"neededEquipments": [
+				"FR"
+			],
+			"name": "Ligne d'Eygurande - Merlines à Clermont-Ferrand",
+			"electrified": false,
+			"group": 1,
+			"objects": [
+				{
+					"start": "XFCLE",
+					"end": "🇫🇷O8309270726",
+					"length": 1,
+					"maxSpeed": 65,
+					"twistingFactor": 0.01
+				},
+				{
+					"start": "🇫🇷O8309270726",
+					"end": "🇫🇷RYA",
+					"length": 3,
+					"maxSpeed": 65,
+					"twistingFactor": 0.42
+				},
+				{
+					"start": "🇫🇷RYA",
+					"end": "🇫🇷DUR",
+					"length": 3,
+					"maxSpeed": 65,
+					"twistingFactor": 0.24
+				},
+				{
+					"start": "🇫🇷DUR",
+					"end": "🇫🇷VOL",
+					"length": 11,
+					"maxSpeed": 70,
+					"twistingFactor": 0.38
+				},
+				{
+					"start": "🇫🇷VOL",
+					"end": "🇫🇷PGB",
+					"length": 18,
+					"maxSpeed": 80,
+					"twistingFactor": 0.39
+				},
+				{
+					"start": "🇫🇷PGB",
+					"end": "🇫🇷O10007530521",
+					"length": 36,
+					"maxSpeed": 75,
+					"twistingFactor": 0.39
+				}
+			]
+		},
+		{
 			"electrified": false,
 			"neededEquipments": [
 				"FR"

--- a/Path.json
+++ b/Path.json
@@ -2420,6 +2420,7 @@
 			],
 			"name": "Ligne de Chartres à Bordeaux",
 			"electrified": false,
+			"maxSpeed": 110,
 			"objects": [
 				{
 					"start": "XFBJ",
@@ -2433,42 +2434,36 @@
 					"start": "🇫🇷GGT",
 					"end": "🇫🇷SMS",
 					"length": 9,
-					"maxSpeed": 110,
 					"twistingFactor": 0.15
 				},
 				{
 					"start": "🇫🇷SMS",
 					"end": "🇫🇷MMM",
 					"length": 16,
-					"maxSpeed": 110,
 					"twistingFactor": 0.16
 				},
 				{
 					"start": "🇫🇷MMM",
 					"end": "🇫🇷JOH",
 					"length": 20,
-					"maxSpeed": 110,
 					"twistingFactor": 0.29
 				},
 				{
 					"start": "🇫🇷JOH",
 					"end": "🇫🇷PNP",
 					"length": 19,
-					"maxSpeed": 110,
 					"twistingFactor": 0.22
 				},
 				{
 					"start": "🇫🇷PNP",
 					"end": "🇫🇷BIL",
 					"length": 15,
-					"maxSpeed": 110,
 					"twistingFactor": 0.3
 				},
 				{
 					"start": "🇫🇷BIL",
 					"end": "XFSAS",
 					"length": 10,
-					"maxSpeed": 110,
 					"twistingFactor": 0.3
 				}
 			]

--- a/Path.json
+++ b/Path.json
@@ -11375,10 +11375,17 @@
 				},
 				{
 					"start": "XFAVV",
-					"end": "XFARL",
+					"end": "XFTA",
 					"length": 31,
 					"maxSpeed": 200,
 					"twistingFactor": 0.2
+				},
+				{
+					"start": "XFTA",
+					"end": "XFARL",
+					"length": 13,
+					"maxSpeed": 200,
+					"twistingFactor": 0.15
 				},
 				{
 					"start": "XFARL",
@@ -38025,7 +38032,7 @@
 			"objects": [
 				{
 					"twistingFactor": 0.2,
-					"start": "XFARL",
+					"start": "XFTA",
 					"end": "🇫🇷NPG",
 					"length": 28
 				},

--- a/Path.json
+++ b/Path.json
@@ -2478,12 +2478,12 @@
 			"neededEquipments": [
 				"FR"
 			],
+			"electrified": false,
 			"name": "Ligne de Nantes-Orléans à Saintes",
 			"objects": [
 				{
 					"start": "XFSAS",
 					"end": "🇫🇷O2499751455",
-					"electrified": false,
 					"length": 16,
 					"maxSpeed": 120,
 					"twistingFactor": 0.21
@@ -2491,7 +2491,6 @@
 				{
 					"start": "🇫🇷O2499751455",
 					"end": "🇫🇷BOR",
-					"electrified": false,
 					"length": 10,
 					"maxSpeed": 120,
 					"twistingFactor": 0.17
@@ -2499,7 +2498,6 @@
 				{
 					"start": "🇫🇷BOR",
 					"end": "🇫🇷O10774711786",
-					"electrified": false,
 					"length": 10,
 					"maxSpeed": 120,
 					"twistingFactor": 0.25
@@ -2507,7 +2505,6 @@
 				{
 					"start": "🇫🇷O10774711786",
 					"end": "🇫🇷RCT",
-					"electrified": false,
 					"length": 6,
 					"maxSpeed": 100,
 					"twistingFactor": 0.32
@@ -2515,7 +2512,6 @@
 				{
 					"start": "🇫🇷RCT",
 					"end": "🇫🇷O2688098190",
-					"electrified": false,
 					"length": 7,
 					"maxSpeed": 100,
 					"twistingFactor": 0.19
@@ -2523,7 +2519,6 @@
 				{
 					"start": "🇫🇷O2688098190",
 					"end": "🇫🇷O9964803133",
-					"electrified": false,
 					"length": 11,
 					"maxSpeed": 120,
 					"twistingFactor": 0.16
@@ -2531,7 +2526,6 @@
 				{
 					"start": "🇫🇷O9964803133",
 					"end": "🇫🇷AOM",
-					"electrified": false,
 					"length": 3,
 					"maxSpeed": 110,
 					"twistingFactor": 0.01
@@ -2539,7 +2533,6 @@
 				{
 					"start": "🇫🇷AOM",
 					"end": "🇫🇷ATL",
-					"electrified": false,
 					"length": 2,
 					"maxSpeed": 110,
 					"twistingFactor": 0.01
@@ -2547,7 +2540,6 @@
 				{
 					"start": "🇫🇷ATL",
 					"end": "🇫🇷O2985684668",
-					"electrified": true,
 					"length": 3,
 					"maxSpeed": 110,
 					"twistingFactor": 0.26
@@ -2555,7 +2547,6 @@
 				{
 					"start": "🇫🇷O2985684668",
 					"end": "🇫🇷LRK",
-					"electrified": false,
 					"length": 65,
 					"maxSpeed": 130,
 					"twistingFactor": 0.35
@@ -2563,7 +2554,6 @@
 				{
 					"start": "🇫🇷LRK",
 					"end": "XFLRY",
-					"electrified": false,
 					"length": 36,
 					"maxSpeed": 130,
 					"twistingFactor": 0.29

--- a/Station.json
+++ b/Station.json
@@ -44113,6 +44113,36 @@
 			"proj": 3
 		},
 		{
+			"name": "Gannat",
+			"ril100": "XFGAN",
+			"group": 2,
+			"x": -473,
+			"y": 946,
+			"platformLength": 343,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Aigueperse",
+			"ril100": "🇫🇷AGE",
+			"group": 2,
+			"x": -474,
+			"y": 959,
+			"platformLength": 164,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Pontmort",
+			"ril100": "🇫🇷PMT",
+			"group": 5,
+			"x": -480,
+			"y": 972,
+			"platformLength": 168,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
 			"group": 5,
 			"name": "Anrath",
 			"ril100": "KANR",

--- a/Station.json
+++ b/Station.json
@@ -6659,6 +6659,104 @@
 			"proj": 3
 		},
 		{
+			"name": "La Jarrie",
+			"ril100": "🇫🇷48518",
+			"group": 2,
+			"x": -1064,
+			"y": 942,
+			"proj": 3
+		},
+		{
+			"name": "Aigrefeuille–Le Thou",
+			"ril100": "🇫🇷48519",
+			"group": 2,
+			"x": -1054,
+			"y": 946,
+			"proj": 3
+		},
+		{
+			"name": "Surgères",
+			"ril100": "🇫🇷SGE",
+			"group": 2,
+			"x": -1028,
+			"y": 943,
+			"proj": 3
+		},
+		{
+			"name": "Mauzé",
+			"ril100": "🇫🇷MAZ",
+			"group": 2,
+			"x": -1015,
+			"y": 928,
+			"proj": 3
+		},
+		{
+			"name": "Niort",
+			"ril100": "🇫🇷NRT",
+			"group": 1,
+			"x": -983,
+			"y": 908,
+			"proj": 3
+		},
+		{
+			"name": "La Crèche",
+			"ril100": "🇫🇷CCK",
+			"group": 2,
+			"x": -960,
+			"y": 901,
+			"platformLength": 147,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Saint-Maixent-l'École",
+			"ril100": "🇫🇷O2718046618",
+			"group": 2,
+			"x": -947,
+			"y": 894,
+			"platformLength": 195,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "La Mothe-St-Heray",
+			"ril100": "XFLHY",
+			"group": 5,
+			"x": -937,
+			"y": 898,
+			"platformLength": 143,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Pamproux",
+			"ril100": "🇫🇷PAP",
+			"group": 2,
+			"x": -926,
+			"y": 895,
+			"platformLength": 144,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Rouillé",
+			"ril100": "🇫🇷RIL",
+			"group": 5,
+			"x": -913,
+			"y": 891,
+			"platformLength": 170,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Lusignan",
+			"ril100": "🇫🇷LUI",
+			"group": 2,
+			"x": -902,
+			"y": 886,
+			"proj": 3
+		},
+		{
 			"group": 5,
 			"name": "Waldershof",
 			"ril100": "NWDH",
@@ -19079,8 +19177,8 @@
 			"name": "Marçay",
 			"ril100": "🇫🇷O3538165421",
 			"group": 6,
-			"x": -895,
-			"y": 880,
+			"x": -893,
+			"y": 885,
 			"proj": 3
 		},
 		{

--- a/Station.json
+++ b/Station.json
@@ -38151,6 +38151,170 @@
 			"proj": 3
 		},
 		{
+			"name": "Brioude",
+			"ril100": "XFBRD",
+			"group": 2,
+			"x": -453,
+			"y": 1080,
+			"platformLength": 297,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "St-Georges-d'Aurac",
+			"ril100": "🇫🇷SGA",
+			"group": 2,
+			"x": -438,
+			"y": 1104,
+			"platformLength": 262,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Langeac",
+			"ril100": "XFLNC",
+			"group": 2,
+			"x": -439,
+			"y": 1114,
+			"platformLength": 414,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Monistrol-d'Allier",
+			"ril100": "XFMNR",
+			"group": 2,
+			"x": -417,
+			"y": 1136,
+			"platformLength": 238,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Alleyras",
+			"ril100": "🇫🇷AES",
+			"group": 2,
+			"x": -414,
+			"y": 1144,
+			"platformLength": 180,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Chapeauroux",
+			"ril100": "XFCPX",
+			"group": 5,
+			"x": -405,
+			"y": 1158,
+			"platformLength": 266,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Langogne",
+			"ril100": "XFLGG",
+			"group": 2,
+			"x": -389,
+			"y": 1176,
+			"platformLength": 318,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Luc (Lozère)",
+			"ril100": "🇫🇷O9955065545",
+			"group": 5,
+			"x": -384,
+			"y": 1189,
+			"proj": 3
+		},
+		{
+			"name": "La Bastide-St-Laurent-les-Bains",
+			"ril100": "XFLBS",
+			"group": 2,
+			"x": -383,
+			"y": 1199,
+			"platformLength": 297,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Villefort",
+			"ril100": "XFVLF",
+			"group": 2,
+			"x": -381,
+			"y": 1226,
+			"platformLength": 290,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Genolhac",
+			"ril100": "XFGNC",
+			"group": 2,
+			"x": -378,
+			"y": 1241,
+			"platformLength": 246,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Chamborigaud",
+			"ril100": "🇫🇷CBO",
+			"group": 2,
+			"x": -374,
+			"y": 1249,
+			"platformLength": 241,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Ste-Cécile-d'Andorge",
+			"ril100": "🇫🇷SCZ",
+			"group": 5,
+			"x": -375,
+			"y": 1255,
+			"proj": 3
+		},
+		{
+			"name": "La Levade",
+			"ril100": "🇫🇷LLE",
+			"group": 2,
+			"x": -370,
+			"y": 1260,
+			"platformLength": 58,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Grand-Combe-la-Pise",
+			"ril100": "🇫🇷O425322098",
+			"group": 2,
+			"x": -367,
+			"y": 1266,
+			"proj": 3
+		},
+		{
+			"name": "Ales",
+			"ril100": "XFALE",
+			"group": 1,
+			"x": -360,
+			"y": 1278,
+			"platformLength": 321,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "St-Geniès-de-Malgoirès",
+			"ril100": "🇫🇷XGE",
+			"group": 2,
+			"x": -342,
+			"y": 1308,
+			"platformLength": 100,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
 			"name": "Bridgeport",
 			"ril100": "🇺🇸BRP",
 			"group": 1,
@@ -52809,6 +52973,88 @@
 			"proj": 3,
 			"platformLength": 40,
 			"platforms": 1
+		},
+		{
+			"name": "Les Salèlles",
+			"ril100": "🇫🇷SQL",
+			"group": 5,
+			"x": -472,
+			"y": 1218,
+			"proj": 3
+		},
+		{
+			"name": "Chanac",
+			"ril100": "🇫🇷CNA",
+			"group": 5,
+			"x": -462,
+			"y": 1220,
+			"proj": 3
+		},
+		{
+			"name": "Le Bruel",
+			"ril100": "🇫🇷BWQ",
+			"group": 5,
+			"x": -461,
+			"y": 1218,
+			"proj": 3
+		},
+		{
+			"name": "Barjac",
+			"ril100": "🇫🇷BJC",
+			"group": 5,
+			"x": -453,
+			"y": 1215,
+			"proj": 3
+		},
+		{
+			"name": "Balsieges-Bourg",
+			"ril100": "🇫🇷O521515549",
+			"group": 5,
+			"x": -447,
+			"y": 1218,
+			"proj": 3
+		},
+		{
+			"name": "Mende",
+			"ril100": "🇫🇷MDE",
+			"group": 2,
+			"x": -440,
+			"y": 1212,
+			"platformLength": 145,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Bagnols—Chadenet",
+			"ril100": "🇫🇷BCT",
+			"group": 5,
+			"x": -422,
+			"y": 1210,
+			"proj": 3
+		},
+		{
+			"name": "Allenc",
+			"ril100": "🇫🇷AEN",
+			"group": 5,
+			"x": -417,
+			"y": 1208,
+			"proj": 3
+		},
+		{
+			"name": "Belvezet",
+			"ril100": "🇫🇷BVZ",
+			"group": 5,
+			"x": -405,
+			"y": 1205,
+			"proj": 3
+		},
+		{
+			"name": "Chasseradès",
+			"ril100": "🇫🇷CJD",
+			"group": 5,
+			"x": -392,
+			"y": 1206,
+			"proj": 3
 		},
 		{
 			"name": "Mikulášovice střed",

--- a/Station.json
+++ b/Station.json
@@ -61364,6 +61364,74 @@
 			"proj": 3
 		},
 		{
+			"name": "Elne",
+			"ril100": "XFEL",
+			"group": 2,
+			"x": -527,
+			"y": 1538,
+			"platformLength": 429,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Argeles-sur-Mer",
+			"ril100": "XFAR",
+			"group": 2,
+			"x": -519,
+			"y": 1547,
+			"platformLength": 438,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Collioure",
+			"ril100": "XFCLL",
+			"group": 5,
+			"x": -513,
+			"y": 1550,
+			"platformLength": 419,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Port-Vendres",
+			"ril100": "🇫🇷POV",
+			"group": 2,
+			"x": -508,
+			"y": 1552,
+			"platformLength": 468,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Banyuls-sur-Mer",
+			"ril100": "XFBAY",
+			"group": 2,
+			"x": -504,
+			"y": 1558,
+			"platformLength": 447,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Cerbere",
+			"ril100": "XFCE",
+			"group": 2,
+			"x": -499,
+			"y": 1565,
+			"platformLength": 397,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Portbou",
+			"ril100": "🇪🇸O3950732005",
+			"group": 2,
+			"x": -502,
+			"y": 1570,
+			"proj": 3
+		},
+		{
 			"name": "Figueres",
 			"ril100": "XEFI",
 			"group": 1,

--- a/Station.json
+++ b/Station.json
@@ -70422,6 +70422,14 @@
 			"proj": 3
 		},
 		{
+			"name": "Tarascon",
+			"ril100": "XFTA",
+			"group": 2,
+			"x": -280,
+			"y": 1334,
+			"proj": 3
+		},
+		{
 			"name": "Arles",
 			"ril100": "XFARL",
 			"group": 1,

--- a/Station.json
+++ b/Station.json
@@ -96045,6 +96045,62 @@
 			"proj": 3
 		},
 		{
+			"name": "Clermont-La Rotonde",
+			"ril100": "🇫🇷O8309270726",
+			"group": 5,
+			"x": -491,
+			"y": 1001,
+			"platformLength": 28,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Royat—Chamalières",
+			"ril100": "🇫🇷RYA",
+			"group": 5,
+			"x": -495,
+			"y": 1001,
+			"platformLength": 177,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Durtol—Nohanent",
+			"ril100": "🇫🇷DUR",
+			"group": 5,
+			"x": -497,
+			"y": 997,
+			"platformLength": 149,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Volvic",
+			"ril100": "🇫🇷VOL",
+			"group": 2,
+			"x": -503,
+			"y": 985,
+			"platformLength": 196,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Pontgibaud",
+			"ril100": "🇫🇷PGB",
+			"group": 6,
+			"x": -525,
+			"y": 992,
+			"proj": 3
+		},
+		{
+			"name": "La Vergnère",
+			"ril100": "🇫🇷O10007530521",
+			"group": 2,
+			"x": -538,
+			"y": 1031,
+			"proj": 3
+		},
+		{
 			"name": "Långsele",
 			"ril100": "🇸🇪O29692552",
 			"group": 6,

--- a/Station.json
+++ b/Station.json
@@ -27192,6 +27192,106 @@
 			"platformLength": 200
 		},
 		{
+			"name": "St-Hilaire—Brizambourg",
+			"ril100": "🇫🇷SBZ",
+			"group": 2,
+			"x": -998,
+			"y": 987,
+			"proj": 3
+		},
+		{
+			"name": "St-Jean-d'Angély",
+			"ril100": "🇫🇷SJA",
+			"group": 2,
+			"x": -994,
+			"y": 972,
+			"platformLength": 200,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Loulay",
+			"ril100": "🇫🇷LLY",
+			"group": 2,
+			"x": -992,
+			"y": 955,
+			"proj": 3
+		},
+		{
+			"name": "Villeneuve-la-Comtesse",
+			"ril100": "🇫🇷VVK",
+			"group": 5,
+			"x": -993,
+			"y": 945,
+			"proj": 3
+		},
+		{
+			"name": "Prissé-la-Charrière",
+			"ril100": "🇫🇷PIH",
+			"group": 5,
+			"x": -990,
+			"y": 936,
+			"proj": 3
+		},
+		{
+			"name": "Beauvoir-sur-Niort",
+			"ril100": "🇫🇷BVK",
+			"group": 2,
+			"x": -986,
+			"y": 932,
+			"platformLength": 132,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Marigny (Deux-Sèvres)",
+			"ril100": "🇫🇷MRJ",
+			"group": 5,
+			"x": -980,
+			"y": 928,
+			"platformLength": 150,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Fors",
+			"ril100": "🇫🇷FOW",
+			"group": 2,
+			"x": -977,
+			"y": 922,
+			"platformLength": 145,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Parthenay",
+			"ril100": "🇫🇷48717",
+			"group": 6,
+			"x": -950,
+			"y": 853,
+			"proj": 3
+		},
+		{
+			"name": "Thouars",
+			"ril100": "🇫🇷THQ",
+			"group": 2,
+			"x": -943,
+			"y": 796,
+			"platformLength": 293,
+			"platforms": 4,
+			"proj": 3
+		},
+		{
+			"name": "Montreuil-Bellay",
+			"ril100": "XFMBE",
+			"group": 2,
+			"x": -933,
+			"y": 773,
+			"platformLength": 318,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
 			"name": "Wrocław Pracze",
 			"ril100": "🇵🇱O11005388582",
 			"group": 2,

--- a/Station.json
+++ b/Station.json
@@ -97291,6 +97291,76 @@
 			"proj": 3
 		},
 		{
+			"name": "Les Sables-d'Olonne",
+			"ril100": "🇫🇷LSO",
+			"group": 2,
+			"x": -1166,
+			"y": 878,
+			"platformLength": 323,
+			"platforms": 3,
+			"proj": 3
+		},
+		{
+			"name": "Olonne-sur-Mer",
+			"ril100": "🇫🇷OSM",
+			"group": 2,
+			"x": -1164,
+			"y": 870,
+			"platformLength": 149,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "La Mothe-Achard",
+			"ril100": "XFLEH",
+			"group": 2,
+			"x": -1148,
+			"y": 860,
+			"platformLength": 220,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Chantonnay",
+			"ril100": "🇫🇷CTO",
+			"group": 2,
+			"x": -1063,
+			"y": 846,
+			"platformLength": 210,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Pouzauges",
+			"ril100": "🇫🇷PZK",
+			"group": 1,
+			"x": -1029,
+			"y": 835,
+			"platformLength": 242,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"name": "Cerizay",
+			"ril100": "🇫🇷CEZ",
+			"group": 1,
+			"x": -1008,
+			"y": 824,
+			"platformLength": 176,
+			"platforms": 1,
+			"proj": 3
+		},
+		{
+			"name": "Bressuire",
+			"ril100": "🇫🇷BRS",
+			"group": 2,
+			"x": -984,
+			"y": 821,
+			"platformLength": 224,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
 			"name": "Biberegg",
 			"ril100": "🇨🇭BIGG",
 			"group": 5,

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -821,7 +821,7 @@
 			"objects": [
 				{
 					"stations": [ "XFM", "🇫🇷NMS", "XFMO", "XFSE", "XFBZ", "XFNB", "XFCN", "XFTM", "🇫🇷AGN", "XFBJ" ],
-					"pathSuggestion": [ "XFM", "XFLES", "XFMI", "XFARL", "🇫🇷NPG", "🇫🇷NMS", "XFMO", "🇫🇷VLM", "XFSE", "XFBZ", "XFNB", "XFCN", "XFTM", "XFMBN", "🇫🇷AGN", "XFBJ" ]
+					"pathSuggestion": [ "XFM", "XFLES", "XFMI", "XFTA", "🇫🇷NPG", "🇫🇷NMS", "XFMO", "🇫🇷VLM", "XFSE", "XFBZ", "XFNB", "XFCN", "XFTM", "XFMBN", "🇫🇷AGN", "XFBJ" ]
 				},
 				{
 					"stations": [ "XFPO", "XFOL", "🇫🇷VER", "XFBGS", "🇫🇷VHY", "XFCLE" ],
@@ -1860,7 +1860,7 @@
 				},
 				{
 					"stations": [ "XFPO", "XFM", "XFNC", "XIVT" ],
-					"pathSuggestion": [ "XFPO", "XFCQ", "🇫🇷SIF", "🇫🇷PAI", "XFD", "XFMAL", "XFLPD", "XFVCV", "🇫🇷BLN", "XFAVV", "XFARL", "XFMI", "XFLES", "XFM", "XFNC", "XIVT" ]
+					"pathSuggestion": [ "XFPO", "XFCQ", "🇫🇷SIF", "🇫🇷PAI", "XFD", "XFMAL", "XFLPD", "XFVCV", "🇫🇷BLN", "XFAVV", "XFTA", "XFMI", "XFLES", "XFM", "XFNC", "XIVT" ]
 				},
 				{
 					"stations": [ "XSMO", "XSIO" ],
@@ -2443,7 +2443,7 @@
 			"objects": [
 				{
 					"stations": [ "XFPO", "XFD", "XFLPD", "XFVCV", "XFAVV", "XFM", "XFTO", "XFCA", "XFNC" ],
-					"pathSuggestion": [ "XFPO", "XFCQ", "XFMEL", "XFLAR", "🇫🇷SIF", "🇫🇷TNN", "XFNUR", "🇫🇷PAI", "XFD", "XFMAL", "XFBV", "🇫🇷ANS", "XFLPD", "XFVI", "🇫🇷TAI", "XFVCV", "🇫🇷LIV", "🇫🇷PRL", "🇫🇷BLN", "XFOR", "🇫🇷BDR", "XFAVV", "XFARL", "XFMI", "XFLES", "XFM", "XFTO", "XFCA", "XFNC" ]
+					"pathSuggestion": [ "XFPO", "XFCQ", "XFMEL", "XFLAR", "🇫🇷SIF", "🇫🇷TNN", "XFNUR", "🇫🇷PAI", "XFD", "XFMAL", "XFBV", "🇫🇷ANS", "XFLPD", "XFVI", "🇫🇷TAI", "XFVCV", "🇫🇷LIV", "🇫🇷PRL", "🇫🇷BLN", "XFOR", "🇫🇷BDR", "XFAVV", "XFTA", "XFMI", "XFLES", "XFM", "XFTO", "XFCA", "XFNC" ]
 				},
 				{
 					"stations": [ "XFPO", "XFD", "XFLPD", "XFVCV", "XFAVV", "XFNB", "XFPE" ],
@@ -7500,7 +7500,7 @@
 						"Fahre den TEE Ligure von %s bis %s"
 					],
 					"stations": [ "XFAVV", "XFM", "XFTO", "XFSR", "XFCA", "XFAN", "XFNC", "XFMC", "XIVT", "XIIO", "XISAV", "XIGP", "XIMB" ],
-					"pathSuggestion": [ "XFAVV", "XFARL", "XFMI", "XFLES", "XFM", "XFTO", "XFSR", "XFCA", "XFAN", "XFNC", "XFMC", "XIVT", "XIIO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIMB" ]
+					"pathSuggestion": [ "XFAVV", "XFTA", "XFMI", "XFLES", "XFM", "XFTO", "XFSR", "XFCA", "XFAN", "XFNC", "XFMC", "XIVT", "XIIO", "XISAV", "XIGP", "XIAQ", "XITOR", "XIMB" ]
 				},
 				{
 					"descriptions": [
@@ -8840,7 +8840,7 @@
 					"stations": [ "🇫🇷TO", "XFOL", "XFPO" ]
 				},
 				{
-					"stations": [ "XFM", "XFLES", "XFMI", "XFARL", "XFAVV" ]
+					"stations": [ "XFM", "XFLES", "XFMI", "XFTA", "XFAVV" ]
 				},
 				{
 					"stations": [ "XFAVV", "🇫🇷BDR", "XFOR", "🇫🇷BLN", "🇫🇷PRL", "XFMN", "XFVCV", "🇫🇷TAI", "XFVI", "XFLPD" ]
@@ -8979,7 +8979,10 @@
 			"group": 1,
 			"objects": [
 				{
-					"stations": [ "XFPE", "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFARL", "XFMI", "XFM" ]
+					"stations": [ "XFPE", "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFTA", "XFMI", "XFM" ]
+				},
+				{
+					"stations": [ "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFTA", "XFAVV" ]
 				},
 				{
 					"stations": [ "🇫🇷AGN", "XFMBN", "XFTM" ]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8945,7 +8945,7 @@
 					"stopsEverywhere": false
 				},
 				{
-					"stations": [ "XFCLE", "XFSGF", "XFSZE", "🇫🇷NVS" ],
+					"stations": [ "XFCLE", "🇫🇷RIO", "XFSGF", "XFSZE", "🇫🇷NVS" ],
 					"stopsEverywhere": true
 				},
 				{
@@ -9027,10 +9027,10 @@
 					"stations": [ "XFTM", "🇫🇷SST", "🇫🇷TES", "🇫🇷RDZ" ]
 				},
 				{
-					"stations": [ "XFBZ", "🇫🇷SYH" ]
+					"stations": [ "XFBZ", "🇫🇷LMR", "🇫🇷SYH" ]
 				},
 				{
-					"stations": [ "XFCLE", "🇫🇷NEU", "🇫🇷O1817739379", "🇫🇷FIG", "🇫🇷CDC", "🇫🇷TES", "🇫🇷SST", "XFTM" ]
+					"stations": [ "XFCLE", "XFARV", "🇫🇷NEU", "🇫🇷O1817739379", "🇫🇷FIG", "🇫🇷CDC", "🇫🇷TES", "🇫🇷SST", "XFTM" ]
 				},
 				{
 					"stations": [ "XFCLE", "XFARV", "🇫🇷SGA", "XFLBS", "🇫🇷NMS" ]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -797,7 +797,7 @@
 				},
 				{
 					"stations": [ "XFPO", "XFOL", "🇫🇷VER", "XFBGS", "🇫🇷VHY", "XFCLE" ],
-					"pathSuggestion": [ "XFPO", "XFOL", "🇫🇷VER", "XFBGS", "🇫🇷GUA", "XFSZE", "XFSGF", "🇫🇷VHY", "XFCLE" ]
+					"pathSuggestion": [ "XFPO", "XFOL", "🇫🇷VER", "XFBGS", "🇫🇷GUA", "XFSZE", "XFSGF", "🇫🇷VHY", "🇫🇷RIO", "XFCLE" ]
 				},
 				{
 					"stations": [ "XFCLE", "🇫🇷RIO", "🇫🇷VHY", "🇫🇷NVS", "🇫🇷VER", "XFOL", "XFPO" ],
@@ -8809,16 +8809,7 @@
 					"stations": [ "XFPO", "🇫🇷VCR", "🇫🇷CHH", "XFCOB", "XFLM" ]
 				},
 				{
-					"stations": [ "XFLM", "🇫🇷SAB", "XFASL", "XFNA" ]
-				},
-				{
-					"stations": [ "XFNA", "🇫🇷SNY", "🇫🇷SNA" ]
-				},
-				{
 					"stations": [ "XFLM", "🇫🇷CIE", "🇫🇷SLG", "🇫🇷EVN", "🇫🇷NEA", "XFLAL", "🇫🇷PTT", "XFVTE", "🇫🇷CTG", "XFR" ]
-				},
-				{
-					"stations": [ "XFNA", "XFASL", "XFSUD", "🇫🇷TO" ]
 				},
 				{
 					"stations": [ "🇫🇷TO", "XFOL", "XFPO" ]
@@ -8875,6 +8866,30 @@
 			"name": "TER von %s nach %s",
 			"service": 2,
 			"descriptions": [
+				"Bringe diesen TER für Aléop von %s nach %s.",
+				"Fahre pünktlich durch Pays de la Loire."
+			],
+			"neededCapacity": [
+				{ "name": "passengers" }
+			],
+			"group": 1,
+			"objects": [
+				{
+					"stations": [ "XFLM", "🇫🇷SAB", "XFASL", "XFNA" ]
+				},
+				{
+					"stations": [ "XFNA", "🇫🇷SNY", "🇫🇷SNA" ]
+				},
+				{
+					"stations": [ "XFNA", "XFASL", "XFSUD", "🇫🇷TO" ]
+				}
+			],
+			"stopsEverywhere": true
+		},
+		{
+			"name": "TER von %s nach %s",
+			"service": 2,
+			"descriptions": [
 				"Bringe diesen TER von %s nach %s.",
 				"Fahre pünktlich durch Auvergne-Rhône-Alpes."
 			],
@@ -8910,6 +8925,10 @@
 				{
 					"stations": [ "XFLPD", "🇫🇷VEI", "🇫🇷BRG", "🇫🇷LTP", "🇫🇷VOR", "XFG" ],
 					"stopsEverywhere": false
+				},
+				{
+					"stations": [ "XFCLE", "🇫🇷VOL" ],
+					"stopsEverywhere": true
 				}
 			]
 		},
@@ -8980,7 +8999,7 @@
 					"stations": [ "🇫🇷MDE", "XFLBS", "🇫🇷NMS" ]
 				},
 				{
-					"stations": [ "🇫🇷MDE", "🇫🇷LMR", "🇫🇷MVJ"]
+					"stations": [ "🇫🇷MDE", "🇫🇷LMR", "🇫🇷MVJ" ]
 				}
 			],
 			"stopsEverywhere": true

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8982,7 +8982,10 @@
 					"stations": [ "XFPE", "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFTA", "XFMI", "XFM" ]
 				},
 				{
-					"stations": [ "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFTA", "XFAVV" ]
+					"stations": [ "🇪🇸O3950732005", "XFPE", "XFNB", "XFBZ", "XFSE", "🇫🇷VLM", "XFLUN", "🇫🇷NMS", "🇫🇷NPG", "XFTA", "XFAVV" ]
+				},
+				{
+					"stations": [ "XFCE", "XFPE", "XFNB", "XFCN", "XFTM" ]
 				},
 				{
 					"stations": [ "🇫🇷AGN", "XFMBN", "XFTM" ]

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -9049,7 +9049,7 @@
 					"stations": [ "XFANG", "🇫🇷LXC", "🇫🇷RUG", "XFPT", "XFCRT" ]
 				},
 				{
-					"stations": [ "🇫🇷TO", "🇫🇷MSD", "XFCRT", "XFPT" ]
+					"stations": [ "🇫🇷TO", "🇫🇷MSD", "🇫🇷MAX", "XFCRT", "XFPT" ]
 				},
 				{
 					"stations": [ "XFBJ", "🇫🇷SMS", "🇫🇷MMM", "🇫🇷JOH", "🇫🇷PNP", "XFSAS", "🇫🇷RCT", "🇫🇷O9964803133", "🇫🇷O2985684668" ],

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -194,6 +194,10 @@
 				{
 					"stations": [ "FF", "RM", "RK", "XFSTG", "XFMV", "XFBMT", "XFBTV", "XFCS", "XFLPD", "XFAVV", "XFAX", "XFM" ],
 					"pathSuggestion": [ "FF", "FFLF", "FDG", "FBL", "RM", "RSAB", "RGN", "RK", "RRA", "RAP", "XFSTG", "XFMV", "XFBMT", "XFBTV", "🇫🇷GLS", "XFD", "XFCS", "XFMAL", "XFSRI", "XFLPD", "🇫🇷GRNY", "XFVCV", "🇫🇷BLN", "XFAVV", "XFAX", "XFM" ]
+				},
+				{
+					"stations": [ "FF", "RM", "RK", "XFSTG", "XFLR", "XFMU", "XFCV", "XFMVC", "🇫🇷MPW", "🇫🇷TO", "XFPT", "XFANG", "XFBJ" ],
+					"pathSuggestion": [ "FF", "FFLF", "FDG", "FBL", "RM", "RSAB", "RBR", "RK", "RRA", "RAP", "XFSTG", "XFVH", "🇫🇷BDC", "XFLR", "XFPS", "XFMU", "XFSHT", "XFCV", "XFVAR", "XFMVC", "🇫🇷MOIS", "XFCQ", "XFPO", "🇫🇷MPW", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "XFANG", "🇫🇷O11799452820", "🇫🇷O3539176369", "🇫🇷GGT", "XFBJ" ]
 				}
 			],
 			"neededCapacity": [
@@ -486,8 +490,24 @@
 					"pathSuggestion": [ "XFPO", "XFVAR", "XFCV", "XFSHT", "XFPS", "XFMZV", "XFTHV", "XLB", "XLL" ]
 				},
 				{
-					"stations": [ "XFPO", "🇫🇷TO", "XFBJ", "XFTM" ],
+					"stations": [ "XFPO", "XFBJ", "🇫🇷AGN", "XFTM" ],
 					"pathSuggestion": [ "XFPO", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "🇫🇷O3539176369", "🇫🇷GGT", "XFBJ", "🇫🇷AGN", "XFMBN", "XFTM" ]
+				},
+				{
+					"stations": [ "XFPO", "XFPT", "XFBJ" ],
+					"pathSuggestion": [ "XFPO", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "🇫🇷O3539176369", "🇫🇷GGT", "XFBJ" ]
+				},
+				{
+					"stations": [ "XFPO", "🇫🇷TO", "XFPT", "XFANG", "🇫🇷LIB", "XFBJ" ],
+					"pathSuggestion": [ "XFPO", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "XFANG", "🇫🇷O11799452820", "XFCOU", "🇫🇷LIB", "XFBJ" ]
+				},
+				{
+					"stations": [ "XFPO", "XFBJ", "🇫🇷FAT", "🇫🇷ARC" ],
+					"pathSuggestion": [ "XFPO", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "🇫🇷O3539176369", "🇫🇷GGT", "XFBJ", "🇫🇷FAT", "🇫🇷ARC" ]
+				},
+				{
+					"stations": [ "XFPO", "🇫🇷MPW", "XFBJ", "XFDX", "🇫🇷ORT", "XFPU", "XFL", "🇫🇷TBS" ],
+					"pathSuggestion": [ "XFPO", "🇫🇷MPW", "🇫🇷CSP", "🇫🇷TO", "🇫🇷MAX", "XFPT", "🇫🇷LXC", "🇫🇷O3539176369", "🇫🇷GGT", "XFBJ", "🇫🇷FAT", "XFMCX", "XFDX", "🇫🇷PUO", "🇫🇷ORT", "XFPU", "XFL", "🇫🇷TBS" ]
 				},
 				{
 					"stations": [ "XFHV", "🇫🇷RRD", "XFPO", "XFLPD", "XFAVV", "XFM" ],
@@ -496,6 +516,14 @@
 				{
 					"stations": [ "XFHE", "XFBR", "XFBY", "XFDX", "XFBJ", "🇫🇷TO", "XFPO" ],
 					"pathSuggestion": [ "XFHE", "XFBR", "XFBY", "XFDX", "XFMCX", "🇫🇷FAT", "XFBJ", "🇫🇷GGT", "🇫🇷O3539176369", "🇫🇷LXC", "XFPT", "🇫🇷MAX", "🇫🇷TO", "🇫🇷CSP", "XFPO" ]
+				},
+				{
+					"stations": [ "🇫🇷O2985684668", "🇫🇷SGE", "🇫🇷NRT", "XFPT", "XFPO" ],
+					"pathSuggestion": [ "🇫🇷O2985684668", "🇫🇷SGE", "🇫🇷NRT", "XFPT", "🇫🇷MAX", "🇫🇷TO", "🇫🇷CSP", "XFPO" ]
+				},
+				{
+					"stations": [ "🇫🇷LSO", "XFLRY", "XFNA", "XFASL", "XFPO" ],
+					"pathSuggestion": [ "🇫🇷LSO", "XFLRY", "XFNA", "XFASL", "🇫🇷SAB", "🇫🇷CIE", "XFCOB", "🇫🇷CSP", "XFPO" ]
 				}
 			],
 			"neededCapacity": [

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8972,6 +8972,15 @@
 				},
 				{
 					"stations": [ "XFCLE", "🇫🇷NEU", "🇫🇷O1817739379", "🇫🇷FIG", "🇫🇷CDC", "🇫🇷TES", "🇫🇷SST", "XFTM" ]
+				},
+				{
+					"stations": [ "XFCLE", "XFARV", "🇫🇷SGA", "XFLBS", "🇫🇷NMS" ]
+				},
+				{
+					"stations": [ "🇫🇷MDE", "XFLBS", "🇫🇷NMS" ]
+				},
+				{
+					"stations": [ "🇫🇷MDE", "🇫🇷LMR", "🇫🇷MVJ"]
 				}
 			],
 			"stopsEverywhere": true

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -8809,9 +8809,6 @@
 					"stations": [ "XFPO", "🇫🇷VCR", "🇫🇷CHH", "XFCOB", "XFLM" ]
 				},
 				{
-					"stations": [ "XFLM", "🇫🇷CIE", "🇫🇷SLG", "🇫🇷EVN", "🇫🇷NEA", "XFLAL", "🇫🇷PTT", "XFVTE", "🇫🇷CTG", "XFR" ]
-				},
-				{
 					"stations": [ "🇫🇷TO", "XFOL", "XFPO" ]
 				},
 				{
@@ -8875,6 +8872,9 @@
 			"group": 1,
 			"objects": [
 				{
+					"stations": [ "XFLM", "🇫🇷CIE", "🇫🇷SLG", "🇫🇷EVN", "🇫🇷NEA", "XFLAL", "🇫🇷PTT", "XFVTE", "🇫🇷CTG", "XFR" ]
+				},
+				{
 					"stations": [ "XFLM", "🇫🇷SAB", "XFASL", "XFNA" ]
 				},
 				{
@@ -8882,6 +8882,12 @@
 				},
 				{
 					"stations": [ "XFNA", "XFASL", "XFSUD", "🇫🇷TO" ]
+				},
+				{
+					"stations": [ "XFNA", "XFLRY", "🇫🇷LSO" ]
+				},
+				{
+					"stations": [ "XFLRY", "🇫🇷THQ", "XFSUD", "🇫🇷TO" ]
 				}
 			],
 			"stopsEverywhere": true
@@ -9091,6 +9097,12 @@
 				},
 				{
 					"stations": [ "XFPT", "🇫🇷BLL", "🇫🇷LIM" ]
+				},
+				{
+					"stations": [ "🇫🇷ROY", "XFSAS", "🇫🇷NRT" ]
+				},
+				{
+					"stations": [ "🇫🇷O2985684668", "🇫🇷NRT", "XFPT" ]
 				}
 			],
 			"stopsEverywhere": true


### PR DESCRIPTION
- Nimes - Arvant
- Perpigan - Portbou und weitere letzte Stichstrecken
- Verbindungstrecken Atlantik -> LGV Sud Europe Atlantique
- dazu gehörend mehr TGV Tasks zu verschiedenen Zielen über LGV
- TER Tasks

Außerdem kleines Refactoring Nimes - Sete - Narbonne und an Tasks sowie
fehlerhafte Elektrifizierung La Rochelle gefixt.

Somit sollte #1026 weitgehend abgeschlossen sein