### PR TITLE
Ammertalbahn

### DIFF
--- a/Path.json
+++ b/Path.json
@@ -90163,6 +90163,66 @@
 					"length": 4
 				}
 			]
+		},
+		{
+			"electrified": true,
+			"name": "Ammertalbahn",
+			"group": 1,
+			"twistingFactor": 0.21,
+			"maxSpeed": 100,
+			"objects": [
+			    {
+					"start": "TT",
+					"end": "TTW",
+					"length": 2,
+					"maxSpeed": 70
+				},
+				{
+					"start": "TTW",
+					"end": "TUJS",
+					"length": 4
+				},
+				{
+					"start": "TUJS",
+					"end": "TUJM",
+					"length": 1,
+					"maxSpeed": 70
+				},
+				{
+					"start": "TUJM",
+					"end": "TPG",
+					"length": 1,
+					"maxSpeed": 70
+				},
+				{
+					"start": "TPG",
+					"end": "TENT",
+					"length": 2,
+					"maxSpeed": 90
+				},
+				{
+					"start": "TENT",
+					"end": "TAG",
+					"length": 5
+				},
+				{
+					"start": "TAG",
+					"end": "TGU",
+					"length": 3
+				},
+				{
+					"start": "TGU",
+					"end": "TZWE",
+					"length": 2,
+					"maxSpeed": 80
+				},
+				{
+					"start": "TZWE",
+					"end": "THE",
+					"length": 2,
+					"maxSpeed": 80
+				}
+			]
 		}
 	]
 }

--- a/Station.json
+++ b/Station.json
@@ -101362,6 +101362,79 @@
 			"y": 428,
 			"platformLength": 140,
 			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Tübingen West",
+			"ril100": "TTW",
+			"x": 339,
+			"y": 536,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Unterjesingen Sandäcker",
+			"ril100": "TUJS",
+			"x": 333,
+			"y": 534,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Unterjesingen Mitte",
+			"ril100": "TUJM",
+			"x": 332,
+			"y": 533,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Pfäffingen",
+			"ril100": "TPG",
+			"x": 330,
+			"y": 531,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 2,
+			"name": "Entringen",
+			"ril100": "TENT",
+			"x": 330,
+			"y": 528,
+			"platformLength": 110,
+			"platforms": 2,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Altingen (Württ)",
+			"ril100": "TAG",
+			"x": 325,
+			"y": 528,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Gültstein",
+			"ril100": "TGU",
+			"x": 322,
+			"y": 527,
+			"platformLength": 110,
+			"proj": 3
+		},
+		{
+			"group": 5,
+			"name": "Herrenberg Zwerchweg",
+			"ril100": "TZWE",
+			"x": 319,
+			"y": 527,
+			"platformLength": 110,
+			"proj": 3
 		}
 	]
 }

--- a/TaskModel.json
+++ b/TaskModel.json
@@ -13887,7 +13887,17 @@
 				"Fahre auf der RB63 von %s nach %s.",
 				"Bring deine Fahrgäste pünktlich auf der Linie RB63 nach %2$s!"
 			],
-			"stations": [ "TUC", "TME", "TRE", "TT" ],
+			"objects": [
+				{
+					"stations": [ "TUC", "TME", "TRE", "TT", "TENT", "THE" ]
+				},
+				{
+					"stations": [ "TT", "TENT" ],
+					"descriptions": [
+						"Fahre einen Kurzläufer der RB63 auf der Ammertalbahn nach %2$s."
+					]
+				}
+			],
 			"stopsEverywhere": true,
 			"neededCapacity": [
 				{ "name": "passengers" }


### PR DESCRIPTION
Folgende Sachen aus #977 werden hinzugefügt:
- neue Strecke Tübingen - Herrenberg
- Verlängerung des bestehenden Tasks RB63 TUC - TT bis THE via TENT (mit zusätzlichem Kurzläufer TT - TENT)