### PR TITLE
Hinzufügung Zulassungen und Netz für irische Insel

### DIFF
--- a/Network.json
+++ b/Network.json
@@ -16,6 +16,11 @@
 			"forRandomTasks": false
 		},
 		{
+			"idString": "irish-broad",
+			"name": "Irische Insel (Breitspur)",
+			"forRandomTasks": false
+		},
+		{
 			"idString": "russian-broad",
 			"name": "Osteuropa/Russland (Breitspur)"
 		},

--- a/Station.json
+++ b/Station.json
@@ -99853,7 +99853,7 @@
 			"platforms": 2,
 			"proj": 3
 		},
-{
+		{
 			"group": 5,
 			"name": "Dornstetten-Aach",
 			"ril100": "TDSA",
@@ -99871,7 +99871,7 @@
 			"platformLength": 140,
 			"proj": 3
 		},
-{
+		{
 			"group": 5,
 			"name": "Freudenstadt Industriegebiet",
 			"ril100": "TFSI",

--- a/TrainEquipment.json
+++ b/TrainEquipment.json
@@ -26,6 +26,11 @@
 					"network": "iberian-broad"
 				},
 				{
+					"idString": "1600mm",
+					"name": "Irische Breitspur",
+					"network": "irish-broad"
+				},
+				{
 					"idString": "1520mm",
 					"name": "Russische Breitspur",
 					"network": "russian-broad"
@@ -98,6 +103,12 @@
 					"network": "uk-standard"
 				},
 				{
+					"idString": "IE",
+					"emoji": "🇮🇪",
+					"name": "Irland",
+					"network": "irish-broad"
+				},
+				{
 					"idString": "IT",
 					"emoji": "🇮🇹",
 					"name": "Italien"
@@ -159,6 +170,12 @@
 					"idString": "MK",
 					"emoji": "🇲🇰",
 					"name": "Nordmazedonien"
+				},
+				{
+					"idString": "NIR",
+					"emoji": "🇬🇧",
+					"name": "Nordirland (Großbritannien)",
+					"network": "irish-broad"
 				},
 				{
 					"idString": "NO",


### PR DESCRIPTION
Hinzufügung von Zulassungen für Irland und Nordirland, irische Breitspur als Ausstattung und irische Insel als eigenes Netz, damit ich diese als Grundlage für Pull Request #1016 verwenden kann.
Wegen der dort genannten Problematik der Nordirland-Situation wäre mein Ansatz jetzt hier, Nordirland als eigene Zulassung hinzuzufügen, da es meiner Ansicht nach technisch gesehen schwierig wäre, die Strecken dort unter Großbritannien zu führen.