### PR TITLE
Zulassungsupdates Traxx AC2 / MS3

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -6409,7 +6409,7 @@
 			"reliability": 1,
 			"cost": 500000,
 			"operationCosts": 80,
-			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "NO", "DE", "IT", "HU"]
+			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "NO", "DE", "HU"]
 		},
 		{
 			"id": 189,

--- a/Train.json
+++ b/Train.json
@@ -6215,7 +6215,7 @@
 			"reliability": 0.95,
 			"cost": 350000,
 			"operationCosts": 95,
-			"equipments": ["ETCS", "LU", "LT", "DE", "AT","CH", "NL","CZ", "BE", "IT", "PL", "DK", "SE", "BG", "HR", "RO", "SK", "SI", "HU", "RS"]
+			"equipments": ["ETCS", "LU", "LT", "DE", "AT","CH", "NL", "CZ", "BE", "IT", "PL", "DK", "SE", "BG", "HR", "RO", "SK", "SI", "HU", "RS", "FR"]
 		},
 		{
 			"id": 4188,
@@ -6231,7 +6231,7 @@
 			"reliability": 0.98,
 			"cost": 395000,
 			"operationCosts": 95,
-			"equipments": ["ETCS", "LU", "LT", "DE", "AT","CH", "NL","CZ", "BE", "IT", "PL", "DK", "SE", "BG", "HR", "RO", "SK", "SI", "HU", "RS"]
+			"equipments": ["ETCS", "LU", "LT", "DE", "AT","CH", "NL", "CZ", "BE", "IT", "PL", "DK", "SE", "BG", "HR", "RO", "SK", "SI", "HU", "RS", "FR"]
 		},
 		{
 			"id": 8817,

--- a/Train.json
+++ b/Train.json
@@ -6409,7 +6409,7 @@
 			"reliability": 1,
 			"cost": 500000,
 			"operationCosts": 80,
-			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "NO", "DE", "HU"]
+			"equipments": ["ETCS", "ES", "FR", "BE", "LU", "DK", "CH", "AT", "SE", "NO", "DE", "HU", "HR", "RS"]
 		},
 		{
 			"id": 189,


### PR DESCRIPTION
1. [Northrail](https://www.alstom.com/de/press-releases-news/2023/6/alstom-northrail-und-rive-private-investment-schliessen-rahmenvertrag-ueber-50-traxx-universal-lokomotiven-einschliesslich-service-paket) und [Akiem](https://www.alstom.com/de/press-releases-news/2023/7/akiem-unterzeichnet-neuen-rahmenvertrag-ueber-100-traxx-mehrsystemlokomotiven-mit-alstom) betreiben Traxx MS3 in Frankreich
3. Traxx AC2 darf nach [Kroatien und Serbien](https://railpool.de/traxx-ac2-fuer-kroatien/)
2. Traxx AC2 kann als Wechselstromlokomotive nicht in Italien (DC) fahren